### PR TITLE
Add config option to control how many times audispd can write to syslog.

### DIFF
--- a/audisp/audispd-config.h
+++ b/audisp/audispd-config.h
@@ -34,6 +34,7 @@ typedef struct daemon_conf
 {
 	unsigned int q_depth;
 	overflow_action_t overflow_action;
+	unsigned int overflow_warning_limit;
 	unsigned int priority_boost;
 	unsigned int max_restarts;
 	node_t node_name_format;

--- a/audisp/queue.c
+++ b/audisp/queue.c
@@ -35,7 +35,6 @@ static const char *SINGLE = "1";
 static const char *HALT = "0";
 static int queue_full_warning = 0;
 extern volatile int hup;
-#define QUEUE_FULL_LIMIT 5
 
 void reset_suspended(void)
 {
@@ -94,11 +93,13 @@ static void do_overflow_action(struct daemon_conf *config)
                 case O_IGNORE:
 			break;
                 case O_SYSLOG:
-			if (queue_full_warning < QUEUE_FULL_LIMIT) {
+			if (!config->overflow_warning_limit ||
+			    queue_full_warning < config->overflow_warning_limit) {
 				syslog(LOG_ERR,
 					"queue is full - dropping event");
 				queue_full_warning++;
-				if (queue_full_warning == QUEUE_FULL_LIMIT)
+				if (config->overflow_warning_limit &&
+				    queue_full_warning == config->overflow_warning_limit)
 					syslog(LOG_ERR,
 						"audispd queue full reporting "
 						"limit reached - ending "

--- a/docs/audispd.conf.5
+++ b/docs/audispd.conf.5
@@ -23,6 +23,13 @@ option will cause the audisp daemon to put the computer system in single user mo
 .I halt
 option will cause the audisp daemon to shutdown the computer system.
 .TP
+.I overflow_warning_limit
+This is a numeric value that controls maximum number of warnings that would be issued to syslog.  Only matters when
+.IR overflow_action
+is set to
+.IR syslog .
+Setting to 0 means there's no limit.  The default is 5.
+.TP
 .I priority_boost
 This is a non-negative number that tells the audit event dispatcher how much of a priority boost it should take. This boost is in addition to the boost provided from the audit daemon. The default is 4. No change is 0.
 .TP


### PR DESCRIPTION
I'm considering adding monitoring for audispd queue overflows by,
essentially, grepping /var/log/messages.  Currently audispd will only
log up to 5 (QUEUE_FULL_LIMIT) messages before stopping writing anything
to the log [1].  That makes the logging significantly less useful.

[1] https://github.com/linux-audit/audit-userspace/blob/master/audisp/queue.c#L96

The change adds a `overflow_warning_limit` option to audispd.conf to
control this.  It also can be set to zero to disable the limit
completely.