### PR TITLE
errormsg: add descriptive macros to replace overloaded error codes

### DIFF
--- a/lib/errormsg.h
+++ b/lib/errormsg.h
@@ -67,6 +67,8 @@ static const struct msg_tab err_msgtab[] = {
     { -29,    1,    "only takes = operator" },
     { -30,    2,    "Field option not supported by kernel:" },
     { -31,    1,    "must be used with exclude, user, or exit filter" },
+    { -32,    0,    "filter is missing from rule" },
+    { -33,    2,    "-C incompatible comparison" },
 };
 #define EAU_OPMISSING		1
 #define EAU_FIELDUNKNOWN	2
@@ -97,4 +99,6 @@ static const struct msg_tab err_msgtab[] = {
 #define EAU_OPEQ		29
 #define EAU_FIELDNOSUPPORT	30
 #define EAU_FIELDNOFILTER	31
+#define EAU_FILTERMISSING	32
+#define EAU_COMPINCOMPAT	33
 #endif

--- a/lib/libaudit.c
+++ b/lib/libaudit.c
@@ -976,7 +976,7 @@ int audit_rule_interfield_comp_data(struct audit_rule_data **rulep,
 	struct audit_rule_data *rule = *rulep;
 
 	if (f == NULL)
-		return -1;
+		return -EAU_FILTERMISSING;
 
 	if (rule->field_count >= (AUDIT_MAX_FIELDS - 1))
 		return -EAU_FIELDTOOMANY;
@@ -1043,7 +1043,7 @@ int audit_rule_interfield_comp_data(struct audit_rule_data **rulep,
 						AUDIT_COMPARE_UID_TO_EUID;
 				break;
 			default:
-				return -1;
+				return -EAU_COMPINCOMPAT;
 			}
 			break;
 		case AUDIT_FSUID:
@@ -1069,7 +1069,7 @@ int audit_rule_interfield_comp_data(struct audit_rule_data **rulep,
 						AUDIT_COMPARE_UID_TO_FSUID;
 				break;
 			default:
-				return -1;
+				return -EAU_COMPINCOMPAT;
 			}
 			break;
 		case AUDIT_LOGINUID:
@@ -1095,7 +1095,7 @@ int audit_rule_interfield_comp_data(struct audit_rule_data **rulep,
 						AUDIT_COMPARE_UID_TO_AUID;
 				break;
 			default:
-				return -1;
+				return -EAU_COMPINCOMPAT;
 			}
 			break;
 		case AUDIT_SUID:
@@ -1121,7 +1121,7 @@ int audit_rule_interfield_comp_data(struct audit_rule_data **rulep,
 						AUDIT_COMPARE_UID_TO_SUID;
 				break;
 			default:
-				return -1;
+				return -EAU_COMPINCOMPAT;
 			}
 			break;
 		case AUDIT_OBJ_UID:
@@ -1147,7 +1147,7 @@ int audit_rule_interfield_comp_data(struct audit_rule_data **rulep,
 						AUDIT_COMPARE_SUID_TO_OBJ_UID;
 				break;
 			default:
-				return -1;
+				return -EAU_COMPINCOMPAT;
 			}
 			break;
 		case AUDIT_UID:
@@ -1173,7 +1173,7 @@ int audit_rule_interfield_comp_data(struct audit_rule_data **rulep,
 						AUDIT_COMPARE_UID_TO_SUID;
 				break;
 			default:
-				return -1;
+				return -EAU_COMPINCOMPAT;
 			}
 			break;
 
@@ -1197,7 +1197,7 @@ int audit_rule_interfield_comp_data(struct audit_rule_data **rulep,
 						AUDIT_COMPARE_EGID_TO_SGID;
 				break;
 			default:
-				return -1;
+				return -EAU_COMPINCOMPAT;
 			}
 			break;
 		case AUDIT_FSGID:
@@ -1219,7 +1219,7 @@ int audit_rule_interfield_comp_data(struct audit_rule_data **rulep,
 						 AUDIT_COMPARE_EGID_TO_FSGID;
 				break;
 			default:
-				return -1;
+				return -EAU_COMPINCOMPAT;
 			}
 			break;
 		case AUDIT_GID:
@@ -1241,7 +1241,7 @@ int audit_rule_interfield_comp_data(struct audit_rule_data **rulep,
 						AUDIT_COMPARE_GID_TO_SGID;
 				break;
 			default:
-				return -1;
+				return -EAU_COMPINCOMPAT;
 			}
 			break;
 		case AUDIT_OBJ_GID:
@@ -1263,7 +1263,7 @@ int audit_rule_interfield_comp_data(struct audit_rule_data **rulep,
 						AUDIT_COMPARE_SGID_TO_OBJ_GID;
 				break;
 			default:
-				return -1;
+				return -EAU_COMPINCOMPAT;
 			}
 			break;
 		case AUDIT_SGID:
@@ -1285,11 +1285,11 @@ int audit_rule_interfield_comp_data(struct audit_rule_data **rulep,
 						AUDIT_COMPARE_EGID_TO_SGID;
 				break;
 			default:
-				return -1;
+				return -EAU_COMPINCOMPAT;
 			}
 			break;
 		default:
-			return -1;
+			return -EAU_COMPINCOMPAT;
 			break;
 	}
 	rule->field_count++;
@@ -1389,7 +1389,7 @@ int audit_rule_fieldpair_data(struct audit_rule_data **rulep, const char *pair,
 	struct audit_rule_data *rule = *rulep;
 
 	if (f == NULL)
-		return -1;
+		return -EAU_FILTERMISSING;
 
 	if (rule->field_count >= (AUDIT_MAX_FIELDS - 1))
 		return -EAU_FIELDTOOMANY;


### PR DESCRIPTION
Several return codes were overloaded and no longer giving helpful error
return messages from the field and comparison functions
audit_rule_fieldpair_data() and audit_rule_interfield_comp_data().

Introduce 2 new macros with more helpful error descriptions for filter
missing, incompatible comparison data.

See: https://github.com/linux-audit/audit-userspace/issues/12

Signed-off-by: Richard Guy Briggs <rgb@redhat.com>