### PR TITLE
Fix build with musl libc

### DIFF
--- a/audisp/audispd.c
+++ b/audisp/audispd.c
@@ -34,6 +34,7 @@
 #include <sys/poll.h>
 #include <netdb.h>
 #include <arpa/inet.h>
+#include <limits.h>
 
 #include "audispd-config.h"
 #include "audispd-pconfig.h"

--- a/auparse/auparse.c
+++ b/auparse/auparse.c
@@ -1102,10 +1102,12 @@ static int extract_timestamp(const char *b, au_event_t *e)
 	int rc = 1;
 
         e->host = NULL;
+
+	tmp = alloca(340);
 	if (*b == 'n')
-		tmp = strndupa(b, 340);
+		tmp = strncpy(tmp, b, 340);
 	else
-		tmp = strndupa(b, 80);
+		tmp = strncpy(tmp, b, 80);
 	ptr = audit_strsplit(tmp);
 	if (ptr) {
 		// Optionally grab the node - may or may not be included

--- a/auparse/interpret.c
+++ b/auparse/interpret.c
@@ -819,10 +819,9 @@ static const char *print_proctitle(const char *val)
 		// Proctitle has arguments separated by NUL bytes
 		// We need to write over the NUL bytes with a space
 		// so that we can see the arguments
-		while ((ptr  = rawmemchr(ptr, '\0'))) {
-			if (ptr >= end)
-				break;
-			*ptr = ' ';
+		while (ptr < end) {
+			if (*ptr == '\0')
+				*ptr = ' ';
 			ptr++;
 		}
 	}

--- a/src/auditctl.c
+++ b/src/auditctl.c
@@ -32,6 +32,8 @@
 #include <ctype.h>
 #include <unistd.h>
 #include <sys/utsname.h>
+#include <sys/select.h>
+#include <sys/time.h>
 #include <fcntl.h>
 #include <errno.h>
 #include <libgen.h>	/* For basename */

--- a/src/auditd.c
+++ b/src/auditd.c
@@ -185,7 +185,7 @@ static void child_handler2( int sig )
 
 static int extract_type(const char *str)
 {
-	const char *tptr, *ptr2, *ptr = str;
+	const char *ptr2, *ptr = str;
 	if (*str == 'n') {
 		ptr = strchr(str+1, ' ');
 		if (ptr == NULL)
@@ -194,12 +194,12 @@ static int extract_type(const char *str)
 	}
 	// ptr should be at 't'
 	ptr2 = strchr(ptr, ' ');
-	// get type=xxx in a buffer
-	tptr = strndupa(ptr, ptr2 - ptr);
+
 	// find =
-	str = strchr(tptr, '=');
-	if (str == NULL)
+	str = strchr(ptr, '=');
+	if (str == NULL || str >= ptr2)
 		return -1; // Malformed - bomb out
+
 	// name is 1 past
 	str++;
 	return audit_name_to_msg_type(str);

--- a/src/ausearch-lol.c
+++ b/src/ausearch-lol.c
@@ -135,10 +135,12 @@ static int extract_timestamp(const char *b, event *e)
 	char *ptr, *tmp, *tnode, *ttype;
 
 	e->node = NULL;
+
+	tmp = alloca(340);
 	if (*b == 'n')
-		tmp = strndupa(b, 340);
+		tmp = strncpy(tmp, b, 340);
 	else
-		tmp = strndupa(b, 80);
+		tmp = strncpy(tmp, b, 80);
 	ptr = audit_strsplit(tmp);
 	if (ptr) {
 		// Check to see if this is the node info


### PR DESCRIPTION
Some patches fixing compilation with musl libc.There also seems to be some bad interaction between musl's <stdint.h> and SWIG (see https://bugs.gentoo.org/620006#c4). Would it be possible to remove the <stdint.h> %include in bindings/swig/src/auditswig.i or to change it into an %import?