### PR TITLE
Fix line breakage in auparse_interpret_field manpage

### DIFF
--- a/docs/auparse_interpret_field.3
+++ b/docs/auparse_interpret_field.3
@@ -38,7 +38,9 @@ Returns NULL if there is an error otherwise a pointer to the interpreted value.
 
 .SH "SEE ALSO"
 
-.BR auparse_get_field_int (3), auparse_get_field_str (3), auparse_set_escape_mode (3).
+.BR auparse_get_field_int (3),
+.BR auparse_get_field_str (3),
+.BR auparse_set_escape_mode (3).
 
 .SH AUTHOR
 Steve Grubb


### PR DESCRIPTION
In debian, lintian is complaining about the auparse_interpret_field
manpage with the following warning:
  W: libauparse-dev: manpage-has-errors-from-man usr/share/man/man3/auparse_interpret_field.3.gz 41: warning [p 1, 9.2i]: can't break line

See: https://lintian.debian.org/tags/manpage-has-errors-from-man.html