### PR TITLE
aureport: Adjust code comment for printing RPT_LOGIN reports

### DIFF
--- a/src/aureport-output.c
+++ b/src/aureport-output.c
@@ -540,9 +540,9 @@ void print_per_event_item(llist *l)
 			break;
 		case RPT_LOGIN:
 			// who, addr, terminal, exe, success, event
-			// Special note...uid is used here because that is
-			// the way that the message works. This is because
-			// on failed logins, loginuid is not set.
+			// Special note...loginuid can be used here for
+			// successful logins. loginuid is not set on failed
+			// logins so acct is used in that situation.
 			safe_print_string(((l->s.success == S_FAILED) &&
 				l->s.acct) ? l->s.acct :
 				aulookup_uid(l->s.loginuid,


### PR DESCRIPTION
I started to backport https://github.com/linux-audit/audit-userspace/commit/25097d64344828a80acf681da5c1dacc4ea3c069 and was confused by an old, incorrect code comment. This trivial PR updates the comment to match the code change.