### PR TITLE
Do not rotate logs when num_logs < 2.

### DIFF
--- a/src/auditd-event.c
+++ b/src/auditd-event.c
@@ -968,9 +968,14 @@ static void rotate_logs(unsigned int num_logs)
 	unsigned int len, i;
 	char *oldname, *newname;
 
-	if (config->max_log_size_action == SZ_ROTATE &&
-				config->num_logs < 2)
+	/* Check that log rotation is enabled in the configuration file. There is
+	 * no need to check for max_log_size_action == SZ_ROTATE because this could be
+	 * invoked externally by receiving a USR1 signal, independently on
+	 *  the action parameter. */
+	if (config->num_logs < 2){
+		audit_msg(LOG_NOTICE, "Log rotation disabled (num_logs < 2), skipping");
 		return;
+	}
 
 	/* Close audit file. fchmod and fchown errors are not fatal because we
 	 * already adjusted log file permissions and ownership when opening the


### PR DESCRIPTION
Previously, the check was for (max_log_size_action == SZ_ROTATE && config->num_logs < 2) only. However, the rotate_logs() function can be invoked using a USR1 signal independently on the action defined.

When num_logs = 0 and max_log_file_action = IGNORE (other than ROTATE) the auditd busy-looped due to integer underrun in the for loop.
With num_logs = 1 and max_log_file_action = IGNORE, the oldname was uninitialized.

This commit exits the rotate_logs() function when log rotation is disabled and adds a LOG_NOTICE.