### PR TITLE
Respect write_logs setting set to no

### DIFF
--- a/auparse/auditd-config.c
+++ b/auparse/auditd-config.c
@@ -276,6 +276,9 @@ static int log_file_parser(auparse_state_t *au, const char *val, int line,
 	DIR *d;
 	int fd, mode;
 
+	if (config->write_logs == 0)
+		return 0;
+
 	/* split name into dir and basename. */
 	tdir = strdup(val);
 	if (tdir)

--- a/src/auditd-config.c
+++ b/src/auditd-config.c
@@ -585,6 +585,9 @@ static int log_file_parser(struct nv_pair *nv, int line,
 	int fd, mode;
 	struct stat buf;
 
+	if (config->write_logs == 0)
+		return 0;
+
 	audit_msg(LOG_DEBUG, "log_file_parser called with: %s", nv->value);
 
 	/* get dir from name. */


### PR DESCRIPTION
Fix log file check/creation when file logging is disabled entirely.

This is specifically useful when you have syslog logging module enabled, and
don't want to leave unnecessary cruft such as empty log files.

Otherwise you get the following:

```
# auditd -f
Config file /etc/audit/auditd.conf opened for parsing
local_events_parser called with: yes
write_logs_parser called with: no
log_file_parser called with: /var/log/auditd/current
Could not open dir /var/log/auditd (No such file or directory)
The audit daemon is exiting.
```

I was wondering if that's the right place to do that check.