### PR TITLE
Add support for executable name not equal operator

### DIFF
--- a/lib/libaudit.c
+++ b/lib/libaudit.c
@@ -1585,8 +1585,8 @@ int audit_rule_fieldpair_data(struct audit_rule_data **rulep, const char *pair,
 				uint32_t features = audit_get_features();
 				if ((features & AUDIT_FEATURE_BITMAP_EXECUTABLE_PATH) == 0)
 					return -EAU_FIELDNOSUPPORT;
-				if (op != AUDIT_EQUAL)
-					return -EAU_OPEQ;
+				if (!(op == AUDIT_NOT_EQUAL || op == AUDIT_EQUAL))
+					return -EAU_OPEQNOTEQ;
 				_audit_exeadded = 1;
 			}
 			if (field == AUDIT_FILTERKEY &&


### PR DESCRIPTION
Related kernel GH issue: https://github.com/linux-audit/audit-kernel/issues/53