### PR TITLE
ausearch: Fix incorrect matching of 'uid' field

### DIFF
--- a/src/ausearch-parse.c
+++ b/src/ausearch-parse.c
@@ -276,7 +276,7 @@ static int parse_task_info(lnode *n, search_items *s)
 	}
 	// optionally get uid
 	if (event_uid != -1 || event_tuid) {
-		str = strstr(term, "uid=");
+		str = strstr(term, " uid=");
 		if (str == NULL)
 			return 22;
 		ptr = str + 4;
@@ -824,7 +824,7 @@ static int parse_user(const lnode *n, search_items *s)
 	}
 	// optionally get uid
 	if (event_uid != -1 || event_tuid) {
-		str = strstr(term, "uid=");
+		str = strstr(term, " uid=");
 		if (str == NULL)
 			return 4;
 		ptr = str + 4;
@@ -1009,7 +1009,7 @@ static int parse_user(const lnode *n, search_items *s)
 	// optionally get uid - some records the second uid is what we want.
 	// USER_LOGIN for example.
 	if (event_uid != -1 || event_tuid) {
-		str = strstr(term, "uid=");
+		str = strstr(term, " uid=");
 		if (str) {
 			if (*(str - 1) == 'a' || *(str - 1) == 's' ||
 					*(str - 1) == 'u')
@@ -1270,7 +1270,7 @@ static int parse_login(const lnode *n, search_items *s)
 	}
 	// optionally get uid
 	if (event_uid != -1 || event_tuid) {
-		str = strstr(term, "uid=");
+		str = strstr(term, " uid=");
 		if (str == NULL)
 			return 4;
 		ptr = str + 4;
@@ -1987,7 +1987,7 @@ static int parse_kernel_anom(const lnode *n, search_items *s)
 
 	// optionally get uid
 	if (event_uid != -1 || event_tuid) {
-		str = strstr(term, "uid="); // if promiscuous, we start over
+		str = strstr(term, " uid="); // if promiscuous, we start over
 		if (str) {
 			ptr = str + 4;
 			term = strchr(ptr, ' ');


### PR DESCRIPTION
When auid is not searched for, the parser matches the 'auid' field as
'uid' and skips the actual 'uid' field. This patch fixes it by
searching for " uid=" instead of "uid=".

This is triggered for example on the following record:

```
type=SYSCALL msg=audit(1523350632.356:24): arch=c000003e syscall=87 success=yes exit=0 a0=55d3d55ed2e0 a1=7ffec3e73380 a2=7ffec3e73380 a3=0 items=2 ppid=1452 pid=1455 auid=1000 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=ttyS0 ses=1 comm="perl" exe="/usr/bin/perl" subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 key=(null)
```