### PR TITLE
Don't build auparse/test/ check programs twice in parallel

### DIFF
--- a/auparse/test/Makefile.am
+++ b/auparse/test/Makefile.am
@@ -44,7 +44,7 @@ auparselol_test_LDADD = ${top_builddir}/auparse/libauparse.la \
 
 drop_srcdir = sed 's,$(srcdir)/test,test,'
 
-check: auparse_test auparselol_test lookup_test
+check:
 	test "$(top_srcdir)" = "$(top_builddir)" || \
 			cp $(top_srcdir)/auparse/test/test*.log .
 	LC_ALL=C \


### PR DESCRIPTION
It's a waste of build time and creates a race condition
that can cause parallel builds to fail:

https://buildd.debian.org/status/fetch.php?pkg=audit&arch=i386&ver=1%3A2.8.4-1&stamp=1535453217&raw=0

...
bin/bash ../../libtool  --tag=CC   --mode=link gcc  -g -O2 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security  -Wl,-z,relro -Wl,-z,now -Wl,--as-needed -o lookup_test lookup_test.o ../../auparse/libauparse.la ../../lib/libaudit.la
libtool: link: gcc -g -O2 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wl,-z -Wl,relro -Wl,-z -Wl,now -Wl,--as-needed -o .libs/lookup_test lookup_test.o  ../../auparse/.libs/libauparse.so ../../lib/.libs/libaudit.so
/usr/bin/ld: lookup_test.o: file not recognized: file truncated
collect2: error: ld returned 1 exit status
make[4]: *** [Makefile:445: lookup_test] Error 1
make[4]: *** Waiting for unfinished jobs....
/bin/bash ../../libtool  --tag=CC   --mode=link gcc  -g -O2 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security  -Wl,-z,relro -Wl,-z,now -Wl,--as-needed -o lookup_test lookup_test.o ../../auparse/libauparse.la ../../lib/libaudit.la
libtool: link: gcc -g -O2 -fdebug-prefix-map=/<<PKGBUILDDIR>>=. -fstack-protector-strong -Wformat -Werror=format-security -Wl,-z -Wl,relro -Wl,-z -Wl,now -Wl,--as-needed -o .libs/lookup_test lookup_test.o  ../../auparse/.libs/libauparse.so ../../lib/.libs/libaudit.so
make[5]: Leaving directory '/<<PKGBUILDDIR>>/debian/build/auparse/test'
make[4]: Leaving directory '/<<PKGBUILDDIR>>/debian/build/auparse/test'
make[3]: *** [Makefile:2014: check-recursive] Error 1