### PR TITLE
auparse/test/: Don't build test programs twice in parallel

### DIFF
--- a/auparse/test/Makefile.am
+++ b/auparse/test/Makefile.am
@@ -44,7 +44,7 @@ auparselol_test_LDADD = ${top_builddir}/auparse/libauparse.la \
 
 drop_srcdir = sed 's,$(srcdir)/test,test,'
 
-check: auparse_test auparselol_test lookup_test
+check-local: auparse_test auparselol_test lookup_test
 	test "$(top_srcdir)" = "$(top_builddir)" || \
 			cp $(top_srcdir)/auparse/test/test*.log .
 	LC_ALL=C \


### PR DESCRIPTION
Overwriting check: created a race condition that can cause
parallel builds to fail due to twomake processes in parallel
building the same files.