### PR TITLE
bindings/swig/src/auditswig.i: Do not hardcode the path of stdint.h

### DIFF
--- a/bindings/swig/src/auditswig.i
+++ b/bindings/swig/src/auditswig.i
@@ -41,6 +41,6 @@ typedef unsigned __u32;
 typedef unsigned uid_t;
 %include "/usr/include/linux/audit.h"
 #define __extension__ /*nothing*/
-%include "/usr/include/stdint.h"
+#include <stdint.h>
 %include "../lib/libaudit.h"
 


### PR DESCRIPTION
auditswig.i hard codes the path to stdint.h. That will fail to work with
non-glibc libcs and after moving glibc's headers (#798955). The path is
hard coded, because swig's %include does not search the standard header
search path. Rather than using %include here, we can use #include,
because stdint.h does not declare any functions. Thus swig entirely
ignores stdint.h and leaves the search to the C compiler.

https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=909967