### PR TITLE
Remove `am__py_compile` redefinition

### DIFF
--- a/bindings/swig/python3/Makefile.am
+++ b/bindings/swig/python3/Makefile.am
@@ -25,8 +25,7 @@ AM_CPPFLAGS = -I. -I$(top_builddir) -I${top_srcdir}/lib $(PYTHON3_INCLUDES)
 LIBS = $(top_builddir)/lib/libaudit.la
 SWIG_FLAGS = -python -py3 -modern
 SWIG_INCLUDES = -I. -I$(top_builddir) -I${top_srcdir}/lib $(PYTHON3_INCLUDES)
-# REMOVE SOMEDAY - without overriding this macro, it uses python2
-am__py_compile = PYTHON=$(PYTHON3) $(SHELL) $(py_compile)
+PYTHON = $(PYTHON3)
 py3exec_PYTHON = audit.py
 py3exec_LTLIBRARIES = _audit.la
 py3exec_SOLIBRARIES = _audit.so


### PR DESCRIPTION
`am__py_compile` was previously defined as
```make
am__py_compile = PYTHON=$(PYTHON3) $(SHELL) $(py_compile)
```
As the original definition of `am__py_compile` produced by automake is
```make
am__py_compile = PYTHON=$(PYTHON) $(SHELL) $(py_compile)
```
it should be sufficient to just
```make
PYTHON = $(PYTHON3)
```
in `Makefile.am`