### PR TITLE
When checkpointing a single file, ensure dev/inode details are recorded - Issue#76

### DIFF
--- a/src/ausearch.c
+++ b/src/ausearch.c
@@ -138,6 +138,8 @@ int main(int argc, char *argv[])
 			case S_IFREG:
 			default:
 				rc = process_file(user_file);
+				if (checkpt_filename)
+					(void)set_ChkPtFileDetails(user_file); /* we deal with failures via checkpt_failure later */
 				break;
 		}
 	} else if (force_logs)


### PR DESCRIPTION
When ausearch is run against a single file with checkpointing, the file's device and inode details are not recorded in the checkpoint file. This patch fixes this.