### PR TITLE
Update all paths /var/run -> /run

### DIFF
--- a/init.d/auditd.service
+++ b/init.d/auditd.service
@@ -17,7 +17,7 @@ Documentation=man:auditd(8) https://github.com/linux-audit/audit-documentation
 
 [Service]
 Type=forking
-PIDFile=/var/run/auditd.pid
+PIDFile=/run/auditd.pid
 ExecStart=/sbin/auditd
 ## To not use augenrules, copy this file to /etc/systemd/system/auditd.service
 ## and comment/delete the next line and uncomment the auditctl line.


### PR DESCRIPTION
In recent versions systemd starts complaining:

/usr/lib/systemd/system/auditd.service:12: PIDFile= references path below
legacy directory /var/run/, updating /var/run/auditd.pid → /run/auditd.pid;
please update the unit file accordingly.

So let's just update the paths.