### PR TITLE
Support for unescaping in trusted messages. Take 2

### DIFF
--- a/auparse/interpret.c
+++ b/auparse/interpret.c
@@ -454,6 +454,7 @@ int load_interpretation_list(const char *buffer)
 				*ptr = 0;
 			} else
 				tmp = 0;
+
 			n.val = strdup(val);
 			nvlist_append(&il, &n);
 			nvlist_interp_fixup(&il);


### PR DESCRIPTION
Hi, how I write in https://github.com/linux-audit/audit-userspace/pull/67, this is adds support for unescaping messages via au_unescape()