### PR TITLE
auditd.service (systemd startup file): enable reload

### DIFF
--- a/init.d/auditd.service
+++ b/init.d/auditd.service
@@ -28,6 +28,9 @@ ExecStartPost=-/sbin/augenrules --load
 # the next line after copying the file to /etc/systemd/system/auditd.service
 #ExecStopPost=/sbin/auditctl -R /etc/audit/audit-stop.rules
 
+ExecReload=-/sbin/augenrules --load
+ExecReload=/bin/kill -HUP $MAINPID
+
 ### Security Settings ###
 MemoryDenyWriteExecute=true
 LockPersonality=true


### PR DESCRIPTION
This enables systemctl to reload the service in the expected manner: auditd reloads its configuration, and the rules are reloaded via augenrules. This is expected behavior and required for SysCMs such as puppet which link a service to a file-change.