### PR TITLE
audit_set_pid: add wmode to man page

### DIFF
--- a/docs/audit_set_pid.3
+++ b/docs/audit_set_pid.3
@@ -5,11 +5,11 @@ audit_set_pid \- Set audit daemon process ID
 
 .B #include <libaudit.h>
 .sp
-int audit_set_pid (int fd, int pid);
+int audit_set_pid (int fd, int pid, rep_wait_t wmode);
 
 .SH "DESCRIPTION"
 
-audit_set_pid tells the kernel what the pid is of the audit daemon. When the pid is set to 0, the kernel will log all events to syslog. Otherwise it will try to send events to the netlink connection that has the same pid given by this function. If for some reason the process goes away, the kernel will automatically set the value to 0 itself. Usually this function is called by the audit daemon and not an external program.
+audit_set_pid tells the kernel what the pid is of the audit daemon. When the pid is set to 0, the kernel will log all events to syslog. Otherwise it will try to send events to the netlink connection that has the same pid given by this function. If for some reason the process goes away, the kernel will automatically set the value to 0 itself. Usually this function is called by the audit daemon and not an external program. If wmode is WAIT_YES, the function will wait for an ACK from the kernel.
 
 .SH "RETURN VALUE"
 


### PR DESCRIPTION
The `audit_set_pid` man page is missing the third parameter. I've added it, and briefly extended the usage.