### PR TITLE
Add audit_rule_*_data, small cleanups

### DIFF
--- a/bindings/python/auparse_python.c
+++ b/bindings/python/auparse_python.c
@@ -335,7 +335,7 @@ AuParser_init(AuParser *self, PyObject *args, PyObject *kwds)
         }
     } break;
     case AUSOURCE_FILE: {
-        char *filename = NULL;
+        const char *filename = NULL;
 
         if (!PYSTR_CHECK(source)) {
             PyErr_SetString(PyExc_ValueError, "source must be a string when source_type is AUSOURCE_FILE");

--- a/lib/libaudit.c
+++ b/lib/libaudit.c
@@ -1786,18 +1786,18 @@ int audit_rule_fieldpair_data(struct audit_rule_data **rulep, const char *pair,
 	return 0;
 }
 
-struct audit_rule_data *audit_rule_crete(void)
+struct audit_rule_data *audit_rule_create_data(void)
 {
 	struct audit_rule_data *rule;
 
 	rule = malloc(sizeof(*rule));
 	if (rule != NULL) {
-		audit_rule_init(rule);
+		audit_rule_init_data(rule);
 	}
 	return rule;
 }
 
-void audit_rule_init(struct audit_rule_data *rule)
+void audit_rule_init_data(struct audit_rule_data *rule)
 {
 	memset(rule, 0, sizeof(*rule));
 }

--- a/lib/libaudit.c
+++ b/lib/libaudit.c
@@ -1786,6 +1786,22 @@ int audit_rule_fieldpair_data(struct audit_rule_data **rulep, const char *pair,
 	return 0;
 }
 
+struct audit_rule_data *audit_rule_crete(void)
+{
+	struct audit_rule_data *rule;
+
+	rule = malloc(sizeof(*rule));
+	if (rule != NULL) {
+		audit_rule_init(rule);
+	}
+	return rule;
+}
+
+void audit_rule_init(struct audit_rule_data *rule)
+{
+	memset(rule, 0, sizeof(*rule));
+}
+
 void audit_rule_free_data(struct audit_rule_data *rule)
 {
 	free(rule);

--- a/lib/libaudit.h
+++ b/lib/libaudit.h
@@ -672,9 +672,9 @@ extern int audit_log_user_command(int audit_fd, int type, const char *command,
 
 /* Rule-building helper functions */
 /* Heap-allocates and initializes an audit_rule_data */
-extern struct audit_rule_data *audit_rule_crete(void);
+extern struct audit_rule_data *audit_rule_create_data(void);
 /* Initializes an existing audit_rule_data struct */
-extern void audit_rule_init(struct audit_rule_data *rule);
+extern void audit_rule_init_data(struct audit_rule_data *rule);
 extern int audit_rule_syscall_data(struct audit_rule_data *rule, int scall);
 extern int audit_rule_syscallbyname_data(struct audit_rule_data *rule,
                                           const char *scall);

--- a/lib/libaudit.h
+++ b/lib/libaudit.h
@@ -638,12 +638,12 @@ extern int audit_make_equivalent(int fd, const char *mount_point,
 				const char *subtree);
 
 /* AUDIT_ADD_RULE */
-extern int  audit_add_rule_data(int fd, struct audit_rule_data *rule,
-                                int flags, int action);
+extern int audit_add_rule_data(int fd, struct audit_rule_data *rule,
+                               int flags, int action);
 
 /* AUDIT_DEL_RULE */
-extern int  audit_delete_rule_data(int fd, struct audit_rule_data *rule,
-                                   int flags, int action);
+extern int audit_delete_rule_data(int fd, struct audit_rule_data *rule,
+                                  int flags, int action);
 
 /* The following are for standard formatting of messages */
 extern int audit_value_needs_encoding(const char *str, unsigned int len);
@@ -671,16 +671,21 @@ extern int audit_log_user_command(int audit_fd, int type, const char *command,
         const char *tty, int result);
 
 /* Rule-building helper functions */
-extern int  audit_rule_syscall_data(struct audit_rule_data *rule, int scall);
-extern int  audit_rule_syscallbyname_data(struct audit_rule_data *rule,
+/* Heap-allocates and initializes an audit_rule_data */
+extern struct audit_rule_data *audit_rule_crete(void);
+/* Initializes an existing audit_rule_data struct */
+extern void audit_rule_init(struct audit_rule_data *rule);
+extern int audit_rule_syscall_data(struct audit_rule_data *rule, int scall);
+extern int audit_rule_syscallbyname_data(struct audit_rule_data *rule,
                                           const char *scall);
 /* Note that the following function takes a **, where audit_rule_fieldpair()
  * takes just a *.  That structure may need to be reallocated as a result of
  * adding new fields */
-extern int  audit_rule_fieldpair_data(struct audit_rule_data **rulep,
+extern int audit_rule_fieldpair_data(struct audit_rule_data **rulep,
                                       const char *pair, int flags);
 extern int audit_rule_interfield_comp_data(struct audit_rule_data **rulep,
 					 const char *pair, int flags);
+/* Deallocates the audit_rule_rule object, and any associated resources */
 extern void audit_rule_free_data(struct audit_rule_data *rule);
 
 /* Capability testing functions */

--- a/src/auditctl.c
+++ b/src/auditctl.c
@@ -86,9 +86,8 @@ static int reset_vars(void)
 	exclude = 0;
 	multiple = 0;
 
-	free(rule_new);
-	rule_new = malloc(sizeof(struct audit_rule_data));
-	memset(rule_new, 0, sizeof(struct audit_rule_data));
+	audit_rule_data_free(rule_new);
+	rule_new = audit_rule_data_create();
 	if (fd < 0) {
 		if ((fd = audit_open()) < 0) {
 			audit_msg(LOG_ERR, "Cannot open netlink audit socket");

--- a/src/auditctl.c
+++ b/src/auditctl.c
@@ -86,8 +86,8 @@ static int reset_vars(void)
 	exclude = 0;
 	multiple = 0;
 
-	audit_rule_data_free(rule_new);
-	rule_new = audit_rule_data_create();
+	audit_rule_free_data(rule_new);
+	rule_new = audit_rule_create_data();
 	if (fd < 0) {
 		if ((fd = audit_open()) < 0) {
 			audit_msg(LOG_ERR, "Cannot open netlink audit socket");

--- a/src/autrace.c
+++ b/src/autrace.c
@@ -52,13 +52,12 @@ static int insert_rule(int audit_fd, const char *field)
 	int rc;
 	int flags = AUDIT_FILTER_EXIT;
 	int action = AUDIT_ALWAYS;
-	struct audit_rule_data *rule = malloc(sizeof(struct audit_rule_data));
+	struct audit_rule_data *rule = audit_rule_create_data();
 	int machine = audit_detect_machine();
 	char *t_field = NULL;
 
 	if (rule == NULL)
 		goto err;
-	memset(rule, 0, sizeof(struct audit_rule_data));
 	if (threat) {
 		rc = 0;
 		if (machine != MACH_AARCH64) {


### PR DESCRIPTION
* Throw a const into auparse_python and clean up some spacing
* Add audit_rule_init_data() and audit_rule_data_create() to match audit_rule_data_free(), motivated by transient EINVAL from audit_add_rule (I wasn't initializing buflen to 0)
* Use audit_rule_*_data() in auditctl and autrace