### PR TITLE
auditctl: support configuring audit_backlog_warn_time

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -87,6 +87,7 @@
 - Improve personality interpretation by using PERS_MASK
 - Speedup ausearch/report parsing RAW logging format by caching uid/name lookup
 - Change auparse python bindings to shared object (Issue #121)
+- Optionally print warning when waiting for backlog availability
 
 2.8.3
 - Correct msg function name in LRU debug code

--- a/configure.ac
+++ b/configure.ac
@@ -67,6 +67,8 @@ AC_CHECK_DECLS([AUDIT_FEATURE_VERSION], [], [], [[#include <linux/audit.h>]])
 AC_CHECK_MEMBERS([struct audit_status.feature_bitmap], [], [], [[#include <linux/audit.h>]])
 AC_CHECK_DECLS([AUDIT_VERSION_BACKLOG_WAIT_TIME], [], [], [[#include <linux/audit.h>]])
 AC_CHECK_DECLS([AUDIT_STATUS_BACKLOG_WAIT_TIME], [], [], [[#include <linux/audit.h>]])
+AC_CHECK_DECLS([AUDIT_VERSION_BACKLOG_WARN_TIME], [], [], [[#include <linux/audit.h>]])
+AC_CHECK_DECLS([AUDIT_STATUS_BACKLOG_WARN_TIME], [], [], [[#include <linux/audit.h>]])
 AC_CHECK_DECLS([ADDR_NO_RANDOMIZE],,, [#include <sys/personality.h>])
 dnl; posix_fallocate is used in audisp-remote
 AC_CHECK_FUNCS([posix_fallocate])

--- a/docs/auditctl.8
+++ b/docs/auditctl.8
@@ -13,6 +13,9 @@ Set max number (limit) of outstanding audit buffers allowed (Kernel Default=64) 
 .BI \-\-backlog_wait_time \ \fIwait_time\fP
 Set the time for the kernel to wait (Kernel Default 60*HZ) when the backlog limit is reached before queuing more audit events to be transferred to auditd. The number must be greater than or equal to zero and less that 10 times the default value.
 .TP
+.BI \-\-backlog_warn_time \ \fIthreshold\fP
+If the kernel waits to enqueue an audit event while the backlog limit is exceeded, and the time spent waiting meets or exceeds this \fIthreshold\fP (Kernel Default=0), then a warning with the time spent waiting will be printed. The number must be greater than or equal to zero and less than or equal to \fB--backlog_wait_time\fP.
+.TP
 .B \-c
 Continue loading rules in spite of an error. This summarizes the results of loading the rules. The exit code will not be success if any rule fails to load.
 .TP

--- a/lib/libaudit.c
+++ b/lib/libaudit.c
@@ -518,6 +518,25 @@ int audit_set_backlog_wait_time(int fd, uint32_t bwt)
 	return rc;
 }
 
+int audit_set_backlog_warn_time(int fd, uint32_t bwt)
+{
+	int rc = -1;
+#if HAVE_DECL_AUDIT_VERSION_BACKLOG_WARN_TIME == 1 || \
+    HAVE_DECL_AUDIT_STATUS_BACKLOG_WARN_TIME == 1
+	struct audit_status s;
+
+	memset(&s, 0, sizeof(s));
+	s.mask          = AUDIT_STATUS_BACKLOG_WARN_TIME;
+	s.backlog_warn_time = bwt;
+	rc = audit_send(fd, AUDIT_SET, &s, sizeof(s));
+	if (rc < 0)
+		audit_msg(audit_priority(errno),
+			"Error sending backlog warn time request (%s)",
+			strerror(-rc));
+#endif
+	return rc;
+}
+
 int audit_reset_lost(int fd)
 {
 	int rc;

--- a/lib/libaudit.h
+++ b/lib/libaudit.h
@@ -625,6 +625,7 @@ extern int  audit_set_failure(int fd, uint32_t failure);
 extern int  audit_set_rate_limit(int fd, uint32_t limit);
 extern int  audit_set_backlog_limit(int fd, uint32_t limit);
 int audit_set_backlog_wait_time(int fd, uint32_t bwt);
+int audit_set_backlog_warn_time(int fd, uint32_t bwt);
 int audit_reset_lost(int fd);
 extern int  audit_set_feature(int fd, unsigned feature, unsigned value, unsigned lock);
 extern int  audit_set_loginuid_immutable(int fd);

--- a/src/auditctl-listing.c
+++ b/src/auditctl-listing.c
@@ -565,6 +565,12 @@ int audit_print_reply(struct audit_reply *rep, int fd)
 			printf("backlog_wait_time %u\n",
 				rep->status->backlog_wait_time);
 #endif
+#if HAVE_DECL_AUDIT_VERSION_BACKLOG_WARN_TIME == 1 || \
+    HAVE_DECL_AUDIT_STATUS_BACKLOG_WARN_TIME == 1
+
+			printf("backlog_warn_time %u\n",
+				rep->status->backlog_warn_time);
+#endif
 			printed = 1;
 			break;
 #if defined(HAVE_DECL_AUDIT_FEATURE_VERSION) && \


### PR DESCRIPTION
The kernel audit subsystem has support for configuring
a variable named `audit_backlog_warn_time`.  This commit
adds support to `auditctl` for getting and setting the
value of `audit_backlog_warn_time`.

If `audit_backlog_warn_time` is greater than zero and if,
after sleeping while the length of the audit queue exceeds
the `audit_backlog_limit`, the total time spent sleeping is
greater than or equal to `audit_backlog_warn_time`, then a
warning is printed with the total time spent sleeping and
the value of `audit_backlog_warn_time`.

Signed-off-by: Max Englander <max.englander@gmail.com>