### PR TITLE
allow LOGIN event record to be grouped with its SYSCALL record

### DIFF
--- a/src/ausearch-lol.c
+++ b/src/ausearch-lol.c
@@ -246,12 +246,14 @@ static void check_events(lol *lo, time_t sec)
 			if (cur->l->e.sec + 2 <= sec) { 
 				cur->status = L_COMPLETE;
 				ready++;
-			} else if (cur->l->e.type == AUDIT_PROCTITLE ||
-				    cur->l->e.type < AUDIT_FIRST_EVENT ||
-				    cur->l->e.type >= AUDIT_FIRST_ANOM_MSG ||
-				    cur->l->e.type == AUDIT_KERNEL ||
-				    (cur->l->e.type >= AUDIT_MAC_UNLBL_ALLOW &&
-				    cur->l->e.type <= AUDIT_MAC_CALIPSO_DEL)) {
+			} else if ( cur->l->e.type <  AUDIT_LOGIN            ||
+				   (cur->l->e.type >  AUDIT_LOGIN           &&
+				    cur->l->e.type <  AUDIT_FIRST_EVENT    ) ||
+				    cur->l->e.type == AUDIT_PROCTITLE        ||
+				   (cur->l->e.type >= AUDIT_MAC_UNLBL_ALLOW &&
+				    cur->l->e.type <= AUDIT_MAC_CALIPSO_DEL) ||
+				    cur->l->e.type == AUDIT_KERNEL           ||
+				    cur->l->e.type >= AUDIT_FIRST_ANOM_MSG     ) {
 				// If known to be 1 record event, we are done
 				cur->status = L_COMPLETE;
 				ready++;


### PR DESCRIPTION
LOGIN records were not grouped with the rest of their event, records with the
identical timestamp and serial number:

----
time->Tue Mar 19 12:23:15 2019
type=LOGIN msg=audit(1553012595.401:219): pid=647 uid=0 subj=system_u:system_r:local_login_t:s0-s0:c0.c1023 old-auid=4294967295 auid=0 tty=ttyS0 old-ses=4294967295 ses=1 res=1
----
time->Tue Mar 19 12:23:15 2019
type=PROCTITLE msg=audit(1553012595.401:219): proctitle=2F62696E2F6C6F67696E002D70002D2D0020202020
type=SYSCALL msg=audit(1553012595.401:219): arch=c000003e syscall=1 success=yes exit=1 a0=3 a1=7fff3fb13380 a2=1 a3=0 items=0 ppid=1 pid=647 auid=0 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=ttyS0 ses=1 comm="login" exe="/usr/bin/login" subj=system_u:system_r:local_login_t:s0-s0:c0.c1023 key=(null)
----

Tidy up the list/ranges of records to be in ascending order for easier parsing
and updating by humans.

See the upstream issues
	https://github.com/linux-audit/audit-userspace/issues/86

Signed-off-by: Richard Guy Briggs <rgb@redhat.com>