### PR TITLE
fix FEATURE_VERSION vs FEATURE_BITMAP

### DIFF
--- a/lib/libaudit.c
+++ b/lib/libaudit.c
@@ -560,8 +560,7 @@ int audit_reset_backlog_wait_time_actual(int fd)
 
 int audit_set_feature(int fd, unsigned feature, unsigned value, unsigned lock)
 {
-#if defined(HAVE_DECL_AUDIT_FEATURE_VERSION) && \
-    defined(HAVE_STRUCT_AUDIT_STATUS_FEATURE_BITMAP)
+#if defined(HAVE_DECL_AUDIT_FEATURE_VERSION)
 	int rc;
 	struct audit_features f;
 
@@ -585,8 +584,7 @@ int audit_set_feature(int fd, unsigned feature, unsigned value, unsigned lock)
 
 int audit_request_features(int fd)
 {
-#if defined(HAVE_DECL_AUDIT_FEATURE_VERSION) && \
-    defined(HAVE_STRUCT_AUDIT_STATUS_FEATURE_BITMAP)
+#if defined(HAVE_DECL_AUDIT_FEATURE_VERSION)
 	int rc;
 	struct audit_features f;
 
@@ -605,8 +603,7 @@ int audit_request_features(int fd)
 
 extern int  audit_set_loginuid_immutable(int fd)
 {
-#if defined(HAVE_DECL_AUDIT_FEATURE_VERSION) && \
-    defined(HAVE_STRUCT_AUDIT_STATUS_FEATURE_BITMAP)
+#if defined(HAVE_DECL_AUDIT_FEATURE_VERSION)
 	return audit_set_feature(fd, AUDIT_FEATURE_LOGINUID_IMMUTABLE, 1, 1);
 #else
 	errno = EINVAL;
@@ -627,8 +624,7 @@ static void load_feature_bitmap(void)
 		return;
 	}
 
-#if defined(HAVE_DECL_AUDIT_FEATURE_VERSION) && \
-    defined(HAVE_STRUCT_AUDIT_STATUS_FEATURE_BITMAP)
+#if defined(HAVE_STRUCT_AUDIT_STATUS_FEATURE_BITMAP)
 	if ((rc = audit_request_status(fd)) > 0) {
 		struct audit_reply rep;
 		int i;

--- a/lib/libaudit.h
+++ b/lib/libaudit.h
@@ -514,7 +514,7 @@ struct audit_reply {
 	struct nlmsgerr         *error;
 	struct audit_sig_info   *signal_info;
 	struct daemon_conf      *conf;
-#ifdef AUDIT_FEATURE_BITMAP_ALL
+#ifdef AUDIT_FEATURE_VERSION
 	struct audit_features	*features;
 #endif
 	};

--- a/lib/netlink.c
+++ b/lib/netlink.c
@@ -147,8 +147,7 @@ static int adjust_reply(struct audit_reply *rep, int len)
 	rep->error    = NULL;
 	rep->signal_info = NULL;
 	rep->conf     = NULL;
-#if defined(HAVE_DECL_AUDIT_FEATURE_VERSION) && \
-    defined(HAVE_STRUCT_AUDIT_STATUS_FEATURE_BITMAP)
+#if defined(HAVE_DECL_AUDIT_FEATURE_VERSION)
 	rep->features = NULL;
 #endif
 	if (!NLMSG_OK(rep->nlh, (unsigned int)len)) {
@@ -173,8 +172,7 @@ static int adjust_reply(struct audit_reply *rep, int len)
 		case AUDIT_GET:   
 			rep->status  = NLMSG_DATA(rep->nlh); 
 			break;
-#if defined(HAVE_DECL_AUDIT_FEATURE_VERSION) && \
-    defined(HAVE_STRUCT_AUDIT_STATUS_FEATURE_BITMAP)
+#if defined(HAVE_DECL_AUDIT_FEATURE_VERSION)
 		case AUDIT_GET_FEATURE:
 			rep->features =  NLMSG_DATA(rep->nlh);
 			break;

--- a/src/auditctl-listing.c
+++ b/src/auditctl-listing.c
@@ -576,8 +576,7 @@ int audit_print_reply(struct audit_reply *rep, int fd)
 #endif
 			printed = 1;
 			break;
-#if defined(HAVE_DECL_AUDIT_FEATURE_VERSION) && \
-    defined(HAVE_STRUCT_AUDIT_STATUS_FEATURE_BITMAP)
+#if defined(HAVE_DECL_AUDIT_FEATURE_VERSION)
 		case AUDIT_GET_FEATURE:
 			{
 			uint32_t mask = AUDIT_FEATURE_TO_MASK(

--- a/src/auditctl.c
+++ b/src/auditctl.c
@@ -135,8 +135,7 @@ static void usage(void)
      "    -v                                Version\n"
      "    -w <path>                         Insert watch at <path>\n"
      "    -W <path>                         Remove watch at <path>\n"
-#if defined(HAVE_DECL_AUDIT_FEATURE_VERSION) && \
-    defined(HAVE_STRUCT_AUDIT_STATUS_FEATURE_BITMAP)
+#if defined(HAVE_DECL_AUDIT_FEATURE_VERSION)
      "    --loginuid-immutable              Make loginuids unchangeable once set\n"
 #endif
 #if HAVE_DECL_AUDIT_VERSION_BACKLOG_WAIT_TIME == 1 || \
@@ -533,8 +532,7 @@ static int parse_syscall(const char *optarg)
 
 static struct option long_opts[] =
 {
-#if defined(HAVE_DECL_AUDIT_FEATURE_VERSION) && \
-    defined(HAVE_STRUCT_AUDIT_STATUS_FEATURE_BITMAP)
+#if defined(HAVE_DECL_AUDIT_FEATURE_VERSION)
   {"loginuid-immutable", 0, NULL, 1},
 #endif
 #if HAVE_DECL_AUDIT_VERSION_BACKLOG_WAIT_TIME == 1 || \


### PR DESCRIPTION
Untangle AUDIT_FEATURE_VERSION and AUDIT_FEATURE_BITMAP since they have nothing
to do with each other.

AUDIT_FEATURE_VERSION is a method to enable and lock certain audit features in
the kernel.  Threre are currently only two.

AUDIT_FEATURE_BITMAP is a method to determine what features exist in the kernel
implementation of audit.  There are currently seven.

fixes: a22f13a548d2f26b3fb05b31599f5b12f56d3d07 ("Fix compile time feature detection in auditctl")
fixes: 74327320a25b2d889708002908d6a051b4dfea51 ("Fix compile time feature detection in auditctl")
fixes: f588248775b4f8180b846bbc1681bc54e07871ed ("Better detect struct audit_status existence")
fixes: bed754a651f47f5a83bbf565609e4936b0270269 ("Fix building on old kernels")
Please see issue page https://github.com/linux-audit/audit-userspace/issues/10

Signed-off-by: Richard Guy Briggs <rgb@redhat.com>