### PR TITLE
Code to address issue148 providing both auditd.conf and userspace sol…

### DIFF
--- a/auparse/auditd-config.c
+++ b/auparse/auditd-config.c
@@ -359,8 +359,7 @@ static int eoe_timeout_parser(auparse_state_t *au, const char *val, int line,
 
 void free_config(struct daemon_conf *config)
 {
-	if (config->log_file != NULL)
-		free((void*)config->log_file);
+	free((void*)config->log_file);
 	config->log_file = NULL;
 }
 

--- a/auparse/auditd-config.c
+++ b/auparse/auditd-config.c
@@ -359,7 +359,7 @@ static int eoe_timeout_parser(auparse_state_t *au, const char *val, int line,
 
 void free_config(struct daemon_conf *config)
 {
-	if (config->log_file == NULL)
+	if (config->log_file != NULL)
 		free((void*)config->log_file);
 	config->log_file = NULL;
 }

--- a/auparse/auditd-config.c
+++ b/auparse/auditd-config.c
@@ -61,10 +61,13 @@ static int nv_split(char *buf, struct _pair *nv);
 static const struct kw_pair *kw_lookup(const char *val);
 static int log_file_parser(auparse_state_t *au, const char *val, int line, 
 		struct daemon_conf *config);
+static int eoe_timeout_parser(auparse_state_t *au, const char *val, int line,
+		struct daemon_conf *config);
 
 static const struct kw_pair keywords[] = 
 {
   {"log_file",		log_file_parser },
+  {"end_of_event_timeout", eoe_timeout_parser },
   { NULL,		NULL }
 };
 
@@ -100,6 +103,7 @@ void clear_config(struct daemon_conf *config)
 	config->disk_full_exe = NULL;
 	config->disk_error_action = FA_SYSLOG;
 	config->disk_error_exe = NULL;
+        config->end_of_event_timeout = EOE_TIMEOUT;
 }
 
 int aup_load_config(auparse_state_t *au, struct daemon_conf *config,
@@ -323,8 +327,40 @@ static int log_file_parser(auparse_state_t *au, const char *val, int line,
 	return 0;
 }
 
+
+static int eoe_timeout_parser(auparse_state_t *au, const char *val, int line,
+		struct daemon_conf *config)
+{
+	const char *ptr = val;
+	unsigned long i;
+
+	/* check that all chars are numbers */
+	for (i=0; ptr[i]; i++) {
+		if (!isdigit(ptr[i])) {
+			audit_msg(au, LOG_ERR,
+				"Value %s should only be numbers - line %d",
+				val, line);
+			return 1;
+		}
+	}
+
+	/* convert to unsigned long */
+	errno = 0;
+	i = strtoul(val, NULL, 10);
+	if (errno) {
+		audit_msg(au, LOG_ERR,
+			"Error converting string to a number (%s) - line %d",
+			strerror(errno), line);
+		return 1;
+	}
+	config->end_of_event_timeout = i;
+	return 0;
+}
+
 void free_config(struct daemon_conf *config)
 {
-	free((void*)config->log_file);
+	if (config->log_file == NULL)
+		free((void*)config->log_file);
+	config->log_file = NULL;
 }
 

--- a/auparse/auparse.c
+++ b/auparse/auparse.c
@@ -41,6 +41,8 @@
 static int debug = 0;
 #endif
 
+static time_t	eoe_timeout = EOE_TIMEOUT;
+
 static void init_lib(void) __attribute__ ((constructor));
 static void init_lib(void)
 {
@@ -287,8 +289,8 @@ static void au_check_events(auparse_state_t *au, time_t sec)
                 if (cur->status == EBS_BUILDING) {
                         if ((r = aup_list_get_cur(cur->l)) == NULL)
 				continue;
-                        // If 2 seconds have elapsed, we are done
-                        if (cur->l->e.sec + 2 <= sec) {
+                        // If eoe_timeout seconds have elapsed, we are done
+                        if (cur->l->e.sec + eoe_timeout <= sec) {
                                 cur->status = EBS_COMPLETE;
 				au->au_ready++;
                         } else if ( // FIXME: Check this v remains true
@@ -398,6 +400,32 @@ void print_lol(char *label, au_lol *lol)
 
 
 /* General functions that affect operation of the library */
+
+/*
+ * au_setup_userspace_configitems - load userspace configuration items from auditd.conf
+ *
+ * Args:
+ *  au - pointer to auparseing state structure
+ *
+ * Rtns:
+ *      void
+ */
+static void au_setup_userspace_configitems(auparse_state_t *au)
+{
+	struct daemon_conf config;
+
+        /* Load config so we know where logs are */
+	set_aumessage_mode(au, MSG_STDERR, DBG_NO);
+	aup_load_config(au, &config, TEST_SEARCH);
+
+	// Now over-ride the interal user space configuration items
+
+	if (config.end_of_event_timeout != EOE_TIMEOUT)
+		eoe_timeout = (time_t)config.end_of_event_timeout;
+
+	free_config(&config);
+}
+
 auparse_state_t *auparse_init(ausource_t source, const void *b)
 {
 	char **tmp, **bb = (char **)b, *buf = (char *)b;
@@ -437,6 +465,7 @@ auparse_state_t *auparse_init(ausource_t source, const void *b)
 	au->callback = NULL;
 	au->callback_user_data = NULL;
 	au->callback_user_data_destroy = NULL;
+	au_setup_userspace_configitems(au);
 	switch (source)
 	{
 		case AUSOURCE_LOGS:
@@ -2123,3 +2152,18 @@ const char *auparse_interpret_sock_address(auparse_state_t *au)
 	return auparse_interpret_sock_parts(au, "laddr=");
 }
 
+/*
+ * auparse_set_eoe_timeout - set the end of event timeout value
+ *
+ * Args
+ *	new_tmo	- new timeout value
+ * Rtns
+ *	0	- correctly set
+ *	1	- failed to set
+ */
+int auparse_set_eoe_timeout (time_t new_tmo) {
+	if (new_tmo == 0)
+		return 1;
+	eoe_timeout = new_tmo;
+	return 0;
+}

--- a/auparse/auparse.c
+++ b/auparse/auparse.c
@@ -418,10 +418,7 @@ static void au_setup_userspace_configitems(auparse_state_t *au)
 	set_aumessage_mode(au, MSG_STDERR, DBG_NO);
 	aup_load_config(au, &config, TEST_SEARCH);
 
-	// Now over-ride the interal user space configuration items
-
-	if (config.end_of_event_timeout != EOE_TIMEOUT)
-		eoe_timeout = (time_t)config.end_of_event_timeout;
+	eoe_timeout = (time_t)config.end_of_event_timeout;
 
 	free_config(&config);
 }

--- a/auparse/auparse.h
+++ b/auparse/auparse.h
@@ -67,6 +67,9 @@ int ausearch_add_regex(auparse_state_t *au, const char *expr);
 int ausearch_set_stop(auparse_state_t *au, austop_t where);
 void ausearch_clear(auparse_state_t *au);
 
+/* Function dealing with setting user space configuration items */
+int auparse_set_eoe_timeout (time_t new_tmo);
+
 /* Functions that are part of the auparse_normalize interface */
 
 // This causes the current event to become normalized.

--- a/auparse/internal.h
+++ b/auparse/internal.h
@@ -59,12 +59,15 @@ typedef enum { EVENT_EMPTY, EVENT_ACCUMULATING, EVENT_EMITTED } auparser_state_t
  *      record type = AUDIT_EOE (audit end of event type record), or
  *      record type = AUDIT_PROCTITLE   (we note the AUDIT_PROCTITLE is always
  *                                      the last record), or
+ *	record type = AUDIT_KERNEL (kernel events are one record events), or
  *      record type < AUDIT_FIRST_EVENT (only single record events appear
  *                                      before this type), or
  *      record type >= AUDIT_FIRST_ANOM_MSG (only single record events appear
  *                                      after this type), or
- *      for the stream being processed, the time of the event is over 2 seconds
- *      old
+ *	record type >= AUDIT_MAC_UNLBL_ALLOW && record type <= AUDIT_MAC_CALIPSO_DEL (these are also one record events), or
+ *      for the stream being processed, the time of the event is over eoe_timeout seconds
+ *      old. eoe_timeout is the configuration item, 'end_of_event_timeout', in the auditd.conf
+ *      configuration file. It's default is EOE_TIMEOUT
  *
  * So, under LOL_EVENT processing, a event node (au_lolnode) can be either
  *

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -53,7 +53,7 @@ auparse_init.3 auparse_interpret_field.3 \
 auparse_next_event.3 auparse_next_field.3 auparse_next_record.3 \
 auparse_node_compare.3 auparse_reset.3 auparse_set_escape_mode.3 \
 auparse_normalize.3 auparse_normalize_functions.3 \
-auparse_timestamp_compare.3 ausearch-expression.5 \
+auparse_timestamp_compare.3 auparse_set_eoe_timeout.3 ausearch-expression.5 \
 aureport.8 ausearch.8 ausearch_add_item.3 ausearch_add_interpreted_item.3 \
 ausearch_add_expression.3 ausearch_add_timestamp_item.3 ausearch_add_regex.3 \
 ausearch_add_timestamp_item_ex.3 ausearch_clear.3 \

--- a/docs/auditd.conf.5
+++ b/docs/auditd.conf.5
@@ -350,7 +350,17 @@ This is a non-negative number that tells the audit event dispatcher how many tim
 .TP
 .I plugin_dir
 This is the location that auditd will use to search for its plugin configuration files.
-
+.TP
+.I end_of_event_timeout
+This is a non-negative number of seconds used by the userspace
+.I auparse()
+library routines and the
+.I aureport(8)
+,
+.I ausearch(8)
+utilities to consider an event is complete when parsing an event log stream. For an event stream being processed, if the time of the current event is over
+.I end_of_event_timeout
+seconds old, compared to co-located events, then the event is considered complete. See the NOTES section for more detail.
 .SH NOTES
 In a CAPP environment, the audit trail is considered so important that access to system resources must be denied if an audit trail cannot be created. In this environment, it would be suggested that /var/log/audit be on its own partition. This is to ensure that space detection is accurate and that no other process comes along and consumes part of it.
 .PP
@@ -370,6 +380,47 @@ Specifying a single allowed client port may make it difficult for the
 client to restart their audit subsystem, as it will be unable to
 recreate a connection with the same host addresses and ports until the
 connection closure TIME_WAIT state times out.
+
+.PP
+Auditd events are made up of one or more records. The auditd system cannot guarantee that the set of records that make up an event will occur atomically, that is the stream will have interleaved records of different events, IE
+.PP
+.RS
+.br
+event0_record0
+.br
+event1_record0
+.br
+event2_record0
+.br
+event1_record3
+.br
+event2_record1
+.br
+event1_record4
+.br
+event3_record0
+.br
+.RE
+.PP
+The auditd system does not guarantee that the records that make up an event will appear in order. Thus, when processing event streams, we need to maintain a list of events with their own list of records hence List of List (LOL) event processing.
+
+When processing an event stream we define the end of an event via
+.P
+.RS
+record type = AUDIT_EOE (audit end of event type record), or
+.br
+record type = AUDIT_PROCTITLE (we note the AUDIT_PROCTITLE is always the last record), or
+.br
+record type = AUDIT_KERNEL (kernel events are one record events), or
+.br
+record type < AUDIT_FIRST_EVENT (only single record events appear before this type), or
+.br
+record type >= AUDIT_FIRST_ANOM_MSG (only single record events appear after this type), or
+.br
+record type >= AUDIT_MAC_UNLBL_ALLOW && record type <= AUDIT_MAC_CALIPSO_DEL (these are also one record events), or
+.br
+for the stream being processed, the time of the event is over end_of_event_timeout seconds old.
+.RE
 
 .SH FILES
 .TP

--- a/docs/auparse_set_eoe_timeout.3
+++ b/docs/auparse_set_eoe_timeout.3
@@ -1,0 +1,26 @@
+.TH "AUPARSE_SET_EOE_TIMEOUT" "3" "January 2021" "Red Hat" "Linux Audit API"
+.SH NAME
+auparse_set_eoe_timeout \- set the end of event timeout value
+.SH "SYNOPSIS"
+.B #include <auparse.h>
+.sp
+int auparse_set_eoe_timeout(time_t new_tmo)
+
+.SH "DESCRIPTION"
+
+auparse_set_eoe_timeout is used to set the end of event timeout value (seconds). The value should be a positive integer. If this function is called, it overides any setting in /etc/auditd.conf.
+The function should be called after the \fIauparse_init()\fP function call.
+
+For details on the timeout, see the \fBend_of_event_timeout\fP configuration item description in \fIauditd.conf(5)\fP.
+
+.SH "RETURN VALUE"
+
+Returns \-1 if an error occurs; otherwise, 0 for success.
+
+.SH "SEE ALSO"
+
+.BR auparse_init (3).
+.BR auditd.conf (8).
+
+.SH AUTHOR
+Steve Grubb

--- a/docs/aureport.8
+++ b/docs/aureport.8
@@ -24,6 +24,9 @@ Report about config changes
 .BR \-cr ,\  \-\-crypto
 Report about crypto events
 .TP
+.BR \-\-eoe\-timeout \ \fIseconds\fP
+Set the end of event parsing timeout. See \fBend_of_event_timeout\fP in \fIauditd.conf(5)\fP for details. Note that setting this value will overide any configured value found in /etc/auditd/auditd.conf.
+.TP
 .BR \-e ,\  \-\-event
 Report about events
 .TP
@@ -136,4 +139,5 @@ date -d "`cut \-f1 \-d. /proc/uptime` seconds ago"
 
 .SH "SEE ALSO"
 .BR ausearch (8),
-.BR auditd (8).
+.BR auditd (8),
+.BR auditd.conf (5).

--- a/docs/ausearch.8
+++ b/docs/ausearch.8
@@ -49,6 +49,9 @@ outputting complete events.
 Should the file or the last checkpointed event not be found, one of a number of errors will result and ausearch will terminate. See \fBEXIT STATUS\fP for detail.
 
 .TP
+.BR \-\-eoe\-timeout \ \fIseconds\fP
+Set the end of event parsing timeout. See \fBend_of_event_timeout\fP in \fIauditd.conf(5)\fP for details. Note that setting this value will overide any configured value found in /etc/auditd/auditd.conf.
+.TP
 .BR \-e,\  \-\-exit \ \fIexit-code-or-errno\fP
 Search for an event based on the given syscall \fIexit code or errno\fP.
 .TP
@@ -232,4 +235,5 @@ date -d "`cut \-f1 \-d. /proc/uptime` seconds ago"
 
 .SH "SEE ALSO"
 .BR auditd (8),
+.BR auditd.conf (5),
 .BR pam_loginuid (8).

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -41,10 +41,10 @@ auditctl_CFLAGS = -fPIE -DPIE -g -D_GNU_SOURCE
 auditctl_LDFLAGS = -pie -Wl,-z,relro -Wl,-z,now
 auditctl_LDADD = -L${top_builddir}/lib -laudit -L${top_builddir}/auparse -lauparse -L${top_builddir}/common -laucommon
 
-aureport_SOURCES = aureport.c auditd-config.c ausearch-llist.c aureport-options.c ausearch-string.c ausearch-parse.c aureport-scan.c aureport-output.c ausearch-lookup.c ausearch-int.c ausearch-time.c ausearch-nvpair.c ausearch-avc.c ausearch-lol.c
+aureport_SOURCES = aureport.c auditd-config.c ausearch-llist.c aureport-options.c ausearch-string.c ausearch-parse.c aureport-scan.c aureport-output.c ausearch-lookup.c ausearch-int.c ausearch-time.c ausearch-nvpair.c ausearch-avc.c ausearch-lol.c ausearch-userspace.c
 aureport_LDADD = -L${top_builddir}/lib -laudit -L${top_builddir}/auparse -lauparse -L${top_builddir}/common -laucommon
 
-ausearch_SOURCES = ausearch.c auditd-config.c ausearch-llist.c ausearch-options.c ausearch-report.c ausearch-match.c ausearch-string.c ausearch-parse.c ausearch-int.c ausearch-time.c ausearch-nvpair.c ausearch-lookup.c ausearch-avc.c ausearch-lol.c ausearch-checkpt.c
+ausearch_SOURCES = ausearch.c auditd-config.c ausearch-llist.c ausearch-options.c ausearch-report.c ausearch-match.c ausearch-string.c ausearch-parse.c ausearch-int.c ausearch-time.c ausearch-nvpair.c ausearch-lookup.c ausearch-avc.c ausearch-lol.c ausearch-checkpt.c ausearch-userspace.c
 ausearch_LDADD = -L${top_builddir}/lib -laudit -L${top_builddir}/auparse -lauparse -L${top_builddir}/common -laucommon
 
 autrace_SOURCES = autrace.c delete_all.c auditctl-llist.c

--- a/src/auditd-config.c
+++ b/src/auditd-config.c
@@ -144,6 +144,8 @@ static int max_restarts_parser(struct nv_pair *nv, int line,
 		struct daemon_conf *config);
 static int plugin_dir_parser(struct nv_pair *nv, int line,
 		struct daemon_conf *config);
+static int eoe_timeout_parser(struct nv_pair *nv, int line,
+		struct daemon_conf *config);
 static int sanity_check(struct daemon_conf *config);
 
 static const struct kw_pair keywords[] = 
@@ -186,6 +188,7 @@ static const struct kw_pair keywords[] =
   {"overflow_action",          overflow_action_parser,          0 },
   {"max_restarts",             max_restarts_parser,             0 },
   {"plugin_dir",               plugin_dir_parser,               0 },
+  {"end_of_event_timeout",     eoe_timeout_parser,              0 },
   { NULL,                      NULL,                            0 }
 };
 
@@ -349,6 +352,7 @@ void clear_config(struct daemon_conf *config)
 	config->max_restarts = 10;
 	config->plugin_dir = strdup("/etc/audit/plugins.d");
 	config->config_dir = NULL;
+	config->end_of_event_timeout = EOE_TIMEOUT;
 }
 
 static log_test_t log_test = TEST_AUDITD;
@@ -1846,6 +1850,37 @@ static int plugin_dir_parser(struct nv_pair *nv, int line,
 	return 0;
 }
 
+static int eoe_timeout_parser(struct nv_pair *nv, int line,
+		struct daemon_conf *config)
+{
+	const char *ptr = nv->value;
+	unsigned long i;
+
+	audit_msg(LOG_DEBUG, "eoe_timeout_parser called with: %s", nv->value);
+
+	/* check that all chars are numbers */
+	for (i=0; ptr[i]; i++) {
+		if (!isdigit(ptr[i])) {
+			audit_msg(LOG_ERR,
+				"Value %s should only be numbers - line %d",
+				nv->value, line);
+			return 1;
+		}
+	}
+
+	/* convert to unsigned long */
+	errno = 0;
+	i = strtoul(nv->value, NULL, 10);
+	if (errno) {
+		audit_msg(LOG_ERR,
+			"Error converting string to a number (%s) - line %d",
+			strerror(errno), line);
+		return 1;
+	}
+	config->end_of_event_timeout = i;
+	return 0;
+}
+
 /*
  * Query file system and calculate in MB the given percentage is.
  * Returns 0 on error and a number otherwise.
@@ -1961,7 +1996,9 @@ void free_config(struct daemon_conf *config)
         free((void *)config->krb5_key_file);
 	free((void *)config->plugin_dir);
         free((void *)config_dir);
-        free(config_file);
+        if (config_file != NULL)
+		free(config_file);
+        config_file = NULL;
 	config->config_dir = NULL;
 }
 

--- a/src/auditd-config.c
+++ b/src/auditd-config.c
@@ -1996,8 +1996,7 @@ void free_config(struct daemon_conf *config)
         free((void *)config->krb5_key_file);
 	free((void *)config->plugin_dir);
         free((void *)config_dir);
-        if (config_file != NULL)
-		free(config_file);
+	free(config_file);
         config_file = NULL;
 	config->config_dir = NULL;
 }

--- a/src/auditd-config.h
+++ b/src/auditd-config.h
@@ -29,6 +29,9 @@
 #define CONFIG_FILE "/etc/audit/auditd.conf"
 #define MEGABYTE 1048576UL
 
+// Define user space end of event timeout default (in seconds)
+#define	EOE_TIMEOUT	2L
+
 typedef enum { D_FOREGROUND, D_BACKGROUND } daemon_t;
 typedef enum { LF_RAW, LF_NOLOG, LF_ENRICHED } logging_formats;
 typedef enum { FT_NONE, FT_INCREMENTAL, FT_INCREMENTAL_ASYNC, FT_DATA, FT_SYNC } flush_technique;
@@ -92,6 +95,8 @@ struct daemon_conf
 	unsigned int max_restarts;
 	char *plugin_dir;
 	const char *config_dir;
+        // Userspace configuration items
+        unsigned long end_of_event_timeout;
 };
 
 void set_allow_links(int allow);

--- a/src/aureport-options.c
+++ b/src/aureport-options.c
@@ -63,6 +63,7 @@ long long event_exit = 0;
 int event_exit_is_set = 0;
 int event_ppid = -1, event_session_id = -2;
 int event_debug = 0, event_machine = -1;
+time_t	arg_eoe_timeout = (time_t)0;
 
 /* These are used by aureport */
 const char *dummy = "dummy";
@@ -86,7 +87,7 @@ enum {  R_INFILE, R_TIME_END, R_TIME_START, R_VERSION, R_SUMMARY, R_LOG_TIMES,
 	R_INTERPRET, R_HELP, R_ANOMALY, R_RESPONSE, R_SUMMARY_DET, R_CRYPTO,
 	R_MAC, R_FAILED, R_SUCCESS, R_ADD, R_DEL, R_AUTH, R_NODE, R_IN_LOGS,
 	R_KEYS, R_TTY, R_NO_CONFIG, R_COMM, R_VIRT, R_INTEG, R_ESCAPE,
-	R_DEBUG };
+	R_DEBUG, R_EOE_TMO };
 
 static struct nv_pair optiontab[] = {
 	{ R_AUTH, "-au" },
@@ -104,6 +105,7 @@ static struct nv_pair optiontab[] = {
 	{ R_EVENTS, "-e" },
 	{ R_EVENTS, "--event" },
 	{ R_ESCAPE, "--escape" },
+	{ R_EOE_TMO, "--eoe-timeout" },
 	{ R_FILES, "-f" },
 	{ R_FILES, "--file" },
 	{ R_FAILED, "--failed" },
@@ -175,6 +177,7 @@ static void usage(void)
 	"\t--comm\t\t\t\tCommands run report\n"
 	"\t-c,--config\t\t\tConfig change report\n"
 	"\t-cr,--crypto\t\t\tCrypto report\n"
+	"\t--eoe-timeout secs\t\tEnd of Event Timeout\n"
 	"\t-e,--event\t\t\tEvent report\n"
 	"\t-f,--file\t\t\tFile name report\n"
 	"\t--failed\t\t\tonly failed events in report\n"
@@ -750,9 +753,31 @@ int check_params(int count, char *vars[])
 			usage();
 			exit(0);
 			break;
+		case R_EOE_TMO:
+			if (!optarg) {
+				fprintf(stderr,
+					"Argument is required for %s\n",
+					vars[c]);
+				retval = -1;
+				break;
+			}
+			if (isdigit(optarg[0])) {
+				errno = 0;
+				arg_eoe_timeout = (time_t)strtoul(optarg, NULL, 10);
+				if (errno || arg_eoe_timeout == 0) {
+					fprintf(stderr,
+						"Illegal value for End of Event Timeout, was %s\n", optarg);
+					retval = -1;
+				}
+				c++;
+			} else {
+				fprintf(stderr,
+					"End of Event Timeout must be a numeric value, was %s\n", optarg);
+				retval = -1;
+			}
+			break;
 		default:
-			fprintf(stderr, "%s is an unsupported option\n", 
-				vars[c]);
+			fprintf(stderr, "%s is an unsupported option\n", vars[c]);
 			retval = -1;
 			break;
 		}

--- a/src/aureport.c
+++ b/src/aureport.c
@@ -64,7 +64,6 @@ extern int force_logs;
 /*
  * User space configuration items
  */
-extern time_t	eoe_timeout;
 extern time_t	arg_eoe_timeout;
 
 
@@ -106,7 +105,7 @@ int main(int argc, char *argv[])
 	 */
 	setup_userspace_configitems();
 	if (arg_eoe_timeout != 0) {
-		eoe_timeout = (time_t)arg_eoe_timeout;
+		lol_set_eoe_timeout(arg_eoe_timeout);
 	}
 
 	lol_create(&lo);

--- a/src/aureport.c
+++ b/src/aureport.c
@@ -61,6 +61,12 @@ static int get_event(llist **);
 extern char *user_file;
 extern int force_logs;
 
+/*
+ * User space configuration items
+ */
+extern time_t	eoe_timeout;
+extern time_t	arg_eoe_timeout;
+
 
 static int is_pipe(int fd)
 {
@@ -95,6 +101,14 @@ int main(int argc, char *argv[])
 	reset_counters();
 
 	print_title();
+	/*
+	 * We set up user space configuration items and THEN apply command line argument overides
+	 */
+	setup_userspace_configitems();
+	if (arg_eoe_timeout != 0) {
+		eoe_timeout = (time_t)arg_eoe_timeout;
+	}
+
 	lol_create(&lo);
 	if (user_file) {
 		struct stat sb;

--- a/src/ausearch-lol.c
+++ b/src/ausearch-lol.c
@@ -35,6 +35,10 @@
 static int ready = 0;
 event very_first_event;
 
+// End of Event timeout value (in seconds). This is over-ridden by auditd-conf's end_of_event_timeout configuration item
+time_t eoe_timeout = EOE_TIMEOUT;
+
+
 void lol_create(lol *lo)
 {
 	int size = ARRAY_LIMIT * sizeof(lolnode);
@@ -242,8 +246,8 @@ static void check_events(lol *lo, time_t sec)
 	for(i=0;i<=lo->maxi; i++) {
 		lolnode *cur = &lo->array[i];
 		if (cur->status == L_BUILDING) {
-			// If 2 seconds have elapsed, we are done
-			if (cur->l->e.sec + 2 <= sec) { 
+			// If eoe_timeout seconds have elapsed, we are done
+			if (cur->l->e.sec + eoe_timeout <= sec) {
 				cur->status = L_COMPLETE;
 				ready++;
 			} else if (cur->l->e.type == AUDIT_PROCTITLE ||
@@ -397,4 +401,3 @@ llist* get_ready_event(lol *lo)
 
 	return NULL;
 }
-

--- a/src/ausearch-lol.c
+++ b/src/ausearch-lol.c
@@ -35,8 +35,8 @@
 static int ready = 0;
 event very_first_event;
 
-// End of Event timeout value (in seconds). This is over-ridden by auditd-conf's end_of_event_timeout configuration item
-time_t eoe_timeout = EOE_TIMEOUT;
+// End of Event timeout value (in seconds). This can be over-riden via configuration or command line argument.
+static time_t eoe_timeout = EOE_TIMEOUT;
 
 
 void lol_create(lol *lo)
@@ -400,4 +400,18 @@ llist* get_ready_event(lol *lo)
 	}
 
 	return NULL;
+}
+
+/*
+ * lol_set_eoe_timeout - set the end of event timeout to given value
+ *
+ * Args
+ * 	new_eoe_tmo - value
+ * Rtn
+ * 	void
+ */
+void
+lol_set_eoe_timeout(time_t new_eoe_tmo)
+{
+	eoe_timeout = new_eoe_tmo;
 }

--- a/src/ausearch-lol.h
+++ b/src/ausearch-lol.h
@@ -51,6 +51,7 @@ int lol_add_record(lol *lo, char *buff);
 void terminate_all_events(lol *lo);
 llist* get_ready_event(lol *lo);
 
+void lol_set_eoe_timeout(time_t new_eoe_tmo);
 void setup_userspace_configitems();
 
 #endif

--- a/src/ausearch-lol.h
+++ b/src/ausearch-lol.h
@@ -51,5 +51,7 @@ int lol_add_record(lol *lo, char *buff);
 void terminate_all_events(lol *lo);
 llist* get_ready_event(lol *lo);
 
+void setup_userspace_configitems();
+
 #endif
 

--- a/src/ausearch-userspace.c
+++ b/src/ausearch-userspace.c
@@ -1,0 +1,40 @@
+/*
+ * ausearch-userspace.c - ausearch userspace configuration code
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include <stdio.h>
+#include "auditd-config.h"
+
+// Set up userspace configuration items from auditd.conf
+// We load the daemon configuration file and update any internal user space configuration
+// items if they are different to default
+
+void setup_userspace_configitems()
+{
+	struct daemon_conf config;
+	extern time_t   eoe_timeout;
+
+	// Load the configuration file 
+	(void)load_config(&config, TEST_SEARCH);
+
+	// Now over-ride the interal user space configuration items
+
+	if (config.end_of_event_timeout != EOE_TIMEOUT)
+		eoe_timeout = (time_t)config.end_of_event_timeout;
+
+	free_config(&config);
+}

--- a/src/ausearch-userspace.c
+++ b/src/ausearch-userspace.c
@@ -18,6 +18,7 @@
 
 #include <stdio.h>
 #include "auditd-config.h"
+#include "ausearch-lol.h"
 
 // Set up userspace configuration items from auditd.conf
 // We load the daemon configuration file and update any internal user space configuration
@@ -26,11 +27,10 @@
 void setup_userspace_configitems()
 {
 	struct daemon_conf config;
-	extern time_t   eoe_timeout;
 
 	// Load the configuration file 
 	(void)load_config(&config, TEST_SEARCH);
 
-	eoe_timeout = (time_t)config.end_of_event_timeout;
+	lol_set_eoe_timeout((time_t)config.end_of_event_timeout);
 	free_config(&config);
 }

--- a/src/ausearch-userspace.c
+++ b/src/ausearch-userspace.c
@@ -31,10 +31,6 @@ void setup_userspace_configitems()
 	// Load the configuration file 
 	(void)load_config(&config, TEST_SEARCH);
 
-	// Now over-ride the interal user space configuration items
-
-	if (config.end_of_event_timeout != EOE_TIMEOUT)
-		eoe_timeout = (time_t)config.end_of_event_timeout;
-
+	eoe_timeout = (time_t)config.end_of_event_timeout;
 	free_config(&config);
 }

--- a/src/ausearch.c
+++ b/src/ausearch.c
@@ -68,6 +68,12 @@ extern int match(llist *l);
 extern void output_record(llist *l);
 extern void ausearch_free_interpretations(void);
 
+/*
+ * User space configuration items
+ */
+extern time_t   eoe_timeout;
+extern time_t   arg_eoe_timeout;
+
 static int is_pipe(int fd)
 {
 	struct stat st;
@@ -125,6 +131,14 @@ int main(int argc, char *argv[])
 		}
 	}
 	
+	/*
+	 * We set up user space configuration items and THEN apply command line argument overides
+	 */
+	setup_userspace_configitems();
+	if (arg_eoe_timeout != 0) {
+		eoe_timeout = (time_t)arg_eoe_timeout;
+	}
+
 	lol_create(&lo);
 	if (user_file) {
 		if (stat(user_file, &sb) == -1) {

--- a/src/ausearch.c
+++ b/src/ausearch.c
@@ -71,7 +71,6 @@ extern void ausearch_free_interpretations(void);
 /*
  * User space configuration items
  */
-extern time_t   eoe_timeout;
 extern time_t   arg_eoe_timeout;
 
 static int is_pipe(int fd)
@@ -136,7 +135,7 @@ int main(int argc, char *argv[])
 	 */
 	setup_userspace_configitems();
 	if (arg_eoe_timeout != 0) {
-		eoe_timeout = (time_t)arg_eoe_timeout;
+		lol_set_eoe_timeout((time_t)arg_eoe_timeout);
 	}
 
 	lol_create(&lo);


### PR DESCRIPTION
This PR addresses issue #148 by providing

- a configuration item in /etc/audit/auditd.conf
- user space changes by providing a --eoe-timeout option to ausearch and aureport and also a auparse_set_eoe_timeout() routine to the auparse stable of functions.