### PR TITLE
statsd: allocate more space to store the IP address

### DIFF
--- a/audisp/plugins/statsd/audisp-statsd.c
+++ b/audisp/plugins/statsd/audisp-statsd.c
@@ -46,7 +46,7 @@ struct daemon_config
 	unsigned int port;
 	unsigned int interval;
 	int sock;
-	struct sockaddr addr;
+	struct sockaddr_storage addr;
 	socklen_t addrlen;
 };
 
@@ -287,7 +287,7 @@ static void send_statsd(void)
 		r.events_anomaly_count, r.events_response_count);
 
 	if (len > 0 && len < (int)sizeof(message))
-		sendto(d.sock, message, len, 0, &d.addr, d.addrlen);
+		sendto(d.sock, message, len, 0, (struct sockaddr *)&d.addr, d.addrlen);
 }
 
 


### PR DESCRIPTION
Currently running /sbin/audisp-statsd from command-line with valid configuration in Fedora 33 crashes as the address doesn't fit into struct sockaddr:

[root@localhost ~]# gdb /sbin/audisp-statsd
GNU gdb (GDB) Fedora 10.1-2.fc33
Copyright (C) 2020 Free Software Foundation, Inc.
License GPLv3+: GNU GPL version 3 or later <http://gnu.org/licenses/gpl.html>
This is free software: you are free to change and redistribute it.
There is NO WARRANTY, to the extent permitted by law.
Type "show copying" and "show warranty" for details.
This GDB was configured as "x86_64-redhat-linux-gnu".
Type "show configuration" for configuration details.
For bug reporting instructions, please see:
<https://www.gnu.org/software/gdb/bugs/>.
Find the GDB manual and other documentation resources online at:
    <http://www.gnu.org/software/gdb/documentation/>.

For help, type "help".
Type "apropos word" to search for commands related to "word"...
Reading symbols from /sbin/audisp-statsd...
Reading symbols from /usr/lib/debug/usr/sbin/audisp-statsd-3.0.1-1.fc33.x86_64.debug...
(gdb) run
Starting program: /usr/sbin/audisp-statsd 
Missing separate debuginfos, use: dnf debuginfo-install glibc-2.32-4.fc33.x86_64
Missing separate debuginfo for /lib64/libauparse.so.0
Try: dnf --enablerepo='*debug*' install /usr/lib/debug/.build-id/2d/a876cb6278c701a87fb4a9e72dc2cf511ccd88.debug
Missing separate debuginfo for /lib64/libaudit.so.1
Try: dnf --enablerepo='*debug*' install /usr/lib/debug/.build-id/8a/56adf299971ed78ac0e30b934e9c7755aafa87.debug
[Thread debugging using libthread_db enabled]
Using host libthread_db library "/lib64/libthread_db.so.1".
*** buffer overflow detected ***: terminated

Program received signal SIGABRT, Aborted.
0x00007ffff7dd29d5 in raise () from /lib64/libc.so.6
Missing separate debuginfos, use: dnf debuginfo-install libcap-ng-0.8-1.fc33.x86_64
(gdb) bt
#0  0x00007ffff7dd29d5 in raise () from /lib64/libc.so.6
#1  0x00007ffff7dbb8a4 in abort () from /lib64/libc.so.6
#2  0x00007ffff7e15177 in __libc_message () from /lib64/libc.so.6
#3  0x00007ffff7ea64ca in __fortify_fail () from /lib64/libc.so.6
#4  0x00007ffff7ea4d66 in __chk_fail () from /lib64/libc.so.6
#5  0x00005555555567c2 in memcpy (__len=<optimized out>, __src=<optimized out>, __dest=0x55555555c3b0 <d+80>)
    at /usr/include/bits/string_fortified.h:29
#6  make_socket () at audisp-statsd.c:184
#7  main () at audisp-statsd.c:322
(gdb) frame 6
#6  make_socket () at audisp-statsd.c:184
184		memcpy(&d.addr, ai->ai_addr, ai->ai_addrlen);
(gdb) 


