### PR TITLE
Avoid Missing return statement in value returning function warning

### DIFF
--- a/src/libev/ev_iouring.c
+++ b/src/libev/ev_iouring.c
@@ -287,7 +287,7 @@ iouring_sqe_get (EV_P)
 }
 
 inline_size
-struct io_uring_sqe *
+void
 iouring_sqe_submit (EV_P_ struct io_uring_sqe *sqe)
 {
   unsigned idx = sqe - EV_SQES;


### PR DESCRIPTION
This isn't actually using the declared return value anywhere.