### PR TITLE
build: Link with libtool archives instead.

### DIFF
--- a/audisp/Makefile.am
+++ b/audisp/Makefile.am
@@ -23,13 +23,13 @@
 SUBDIRS = plugins 
 CONFIG_CLEAN_FILES = *.rej *.orig
 AM_CPPFLAGS = -D_GNU_SOURCE -fPIC -DPIC -I${top_srcdir} -I${top_srcdir}/lib -I${top_srcdir}/src -I${top_srcdir}/src/libev
-LIBS = -L${top_builddir}/lib -laudit 
+LIBS = ${top_builddir}/lib/libaudit.la
 LDADD = -lpthread
 
 noinst_HEADERS = audispd-pconfig.h audispd-llist.h audispd-config.h \
 	queue.h audispd-builtins.h libdisp.h
-libdisp_a_SOURCES = audispd.c audispd-pconfig.c queue.c \
+libdisp_la_SOURCES = audispd.c audispd-pconfig.c queue.c \
 	audispd-llist.c audispd-builtins.c
-libdisp_a_CFLAGS = -fno-strict-aliasing
-noinst_LIBRARIES = libdisp.a
-
+libdisp_la_CFLAGS = -fno-strict-aliasing
+libdisp_la_LDFLAGS = -no-undefined -static
+noinst_LTLIBRARIES = libdisp.la

--- a/audisp/plugins/ids/Makefile.am
+++ b/audisp/plugins/ids/Makefile.am
@@ -37,7 +37,7 @@ audisp_ids_SOURCES = account.c avl.c ids.c ids_config.c model_bad_event.c \
 	model_behavior.c nvpair.c origin.c reactions.c session.c \
 	timer-services.c
 audisp_ids_CFLAGS = -D_GNU_SOURCE
-audisp_ids_LDADD = -L${top_builddir}/lib -laudit -L${top_builddir}/auparse -lauparse -L${top_builddir}/common -laucommon -lpthread
+audisp_ids_LDADD = ${top_builddir}/lib/libaudit.la ${top_builddir}/auparse/libauparse.la ${top_builddir}/common/libaucommon.la -lpthread
 
 install-data-hook:
 	mkdir -p -m 0750 ${DESTDIR}${plugin_confdir}

--- a/audisp/plugins/remote/Makefile.am
+++ b/audisp/plugins/remote/Makefile.am
@@ -37,7 +37,7 @@ audisp_remote_DEPENDENCIES = ${top_builddir}/common/libaucommon.la
 audisp_remote_SOURCES = audisp-remote.c remote-config.c queue.c
 audisp_remote_CFLAGS = -fPIE -DPIE -g -D_REENTRANT -D_GNU_SOURCE -Wundef
 audisp_remote_LDFLAGS = -pie -Wl,-z,relro -Wl,-z,now
-audisp_remote_LDADD = $(CAPNG_LDADD) $(gss_libs) -L${top_builddir}/common -laucommon
+audisp_remote_LDADD = $(CAPNG_LDADD) $(gss_libs) ${top_builddir}/common/libaucommon.la
 
 test_queue_SOURCES = queue.c test-queue.c
 

--- a/audisp/plugins/statsd/Makefile.am
+++ b/audisp/plugins/statsd/Makefile.am
@@ -30,7 +30,7 @@ sbin_PROGRAMS = audisp-statsd
 man_MANS = audisp-statsd.8
 audisp_statsd_SOURCES = audisp-statsd.c
 audisp_statsd_CFLAGS = -g -D_GNU_SOURCE
-audisp_statsd_LDADD = -L${top_builddir}/auparse -lauparse -L${top_builddir}/lib -laudit
+audisp_statsd_LDADD = ${top_builddir}/auparse/libauparse.la ${top_builddir}/lib/libaudit.la
 
 install-data-hook:
 	mkdir -p -m 0750 ${DESTDIR}${plugin_confdir}

--- a/audisp/plugins/syslog/Makefile.am
+++ b/audisp/plugins/syslog/Makefile.am
@@ -33,7 +33,7 @@ audisp_syslog_DEPENDENCIES = ${top_builddir}/common/libaucommon.la
 audisp_syslog_SOURCES = audisp-syslog.c
 audisp_syslog_CFLAGS = -fPIE -DPIE -g -D_GNU_SOURCE -Wundef
 audisp_syslog_LDFLAGS = -pie -Wl,-z,relro -Wl,-z,now
-audisp_syslog_LDADD = $(CAPNG_LDADD) -L${top_builddir}/common -laucommon -L${top_builddir}/auparse -lauparse
+audisp_syslog_LDADD = $(CAPNG_LDADD) ${top_builddir}/common/libaucommon.la ${top_builddir}/auparse/libauparse.la
 
 install-data-hook:
 	mkdir -p -m 0750 ${DESTDIR}${plugin_confdir}

--- a/audisp/plugins/zos-remote/Makefile.am
+++ b/audisp/plugins/zos-remote/Makefile.am
@@ -24,7 +24,7 @@
 AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/lib -I${top_srcdir}/auparse
 CONFIG_CLEAN_FILES = *.rej *.orig
 EXTRA_DIST = zos-remote.conf audispd-zos-remote.conf
-LIBS = -L${top_builddir}/auparse -lauparse
+LIBS = ${top_builddir}/auparse/libauparse.la
 LDADD = -lpthread -lldap -llber $(CAPNG_LDADD) 
 plugin_confdir=$(sysconfdir)/audit
 plugin_conf = zos-remote.conf

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -33,22 +33,21 @@ auditd_SOURCES += auditd-listen.c
 endif
 auditd_CFLAGS = -fPIE -DPIE -g -D_REENTRANT -D_GNU_SOURCE -fno-strict-aliasing -pthread -Wno-pointer-sign
 auditd_LDFLAGS = -pie -Wl,-z,relro -Wl,-z,now
-auditd_DEPENDENCIES = libev/libev.a ${top_builddir}/audisp/libdisp.a
-auditd_LDADD = @LIBWRAP_LIBS@ -Llibev -lev -L${top_builddir}/audisp -ldisp -L${top_builddir}/lib -laudit -L${top_builddir}/auparse -lauparse -lpthread -lrt -lm $(gss_libs) -L${top_builddir}/common -laucommon
+auditd_LDADD = @LIBWRAP_LIBS@ ${top_builddir}/src/libev/libev.la ${top_builddir}/audisp/libdisp.la ${top_builddir}/lib/libaudit.la ${top_builddir}/auparse/libauparse.la -lpthread -lrt -lm $(gss_libs) ${top_builddir}/common/libaucommon.la
 
 auditctl_SOURCES = auditctl.c auditctl-llist.c delete_all.c auditctl-listing.c
 auditctl_CFLAGS = -fPIE -DPIE -g -D_GNU_SOURCE
 auditctl_LDFLAGS = -pie -Wl,-z,relro -Wl,-z,now
-auditctl_LDADD = -L${top_builddir}/lib -laudit -L${top_builddir}/auparse -lauparse -L${top_builddir}/common -laucommon
+auditctl_LDADD = ${top_builddir}/lib/libaudit.la ${top_builddir}/auparse/libauparse.la ${top_builddir}/common/libaucommon.la
 
 aureport_SOURCES = aureport.c auditd-config.c ausearch-llist.c aureport-options.c ausearch-string.c ausearch-parse.c aureport-scan.c aureport-output.c ausearch-lookup.c ausearch-int.c ausearch-time.c ausearch-nvpair.c ausearch-avc.c ausearch-lol.c
-aureport_LDADD = -L${top_builddir}/lib -laudit -L${top_builddir}/auparse -lauparse -L${top_builddir}/common -laucommon
+aureport_LDADD = ${top_builddir}/lib/libaudit.la ${top_builddir}/auparse/libauparse.la ${top_builddir}/common/libaucommon.la
 
 ausearch_SOURCES = ausearch.c auditd-config.c ausearch-llist.c ausearch-options.c ausearch-report.c ausearch-match.c ausearch-string.c ausearch-parse.c ausearch-int.c ausearch-time.c ausearch-nvpair.c ausearch-lookup.c ausearch-avc.c ausearch-lol.c ausearch-checkpt.c
-ausearch_LDADD = -L${top_builddir}/lib -laudit -L${top_builddir}/auparse -lauparse -L${top_builddir}/common -laucommon
+ausearch_LDADD = ${top_builddir}/lib/libaudit.la ${top_builddir}/auparse/libauparse.la ${top_builddir}/common/libaucommon.la
 
 autrace_SOURCES = autrace.c delete_all.c auditctl-llist.c
-autrace_LDADD = -L${top_builddir}/lib -laudit
+autrace_LDADD = ${top_builddir}/lib/libaudit.la
 
 libev/libev.a:
 	make -C libev

--- a/src/libev/Makefile.am
+++ b/src/libev/Makefile.am
@@ -24,6 +24,7 @@ EXTRA_DIST = README ev_epoll.c ev_poll.c ev_select.c ev_iouring.c ev_linuxaio.c 
 AM_CFLAGS = -fPIC -DPIC -g -fno-strict-aliasing ${DEBUG}
 
 noinst_HEADERS = ev.h ev_vars.h ev_wrap.h event.h
-noinst_LIBRARIES = libev.a
+noinst_LTLIBRARIES = libev.la
 
-libev_a_SOURCES = ev.c event.c
+libev_la_SOURCES = ev.c event.c
+libev_la_LDFLAGS = -no-undefined -static

--- a/tools/aulast/Makefile.am
+++ b/tools/aulast/Makefile.am
@@ -23,7 +23,7 @@
 CONFIG_CLEAN_FILES = *.loT *.rej *.orig
 EXTRA_DIST = $(man_MANS)
 AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/lib -I${top_srcdir}/auparse
-LIBS = -L${top_builddir}/auparse -lauparse
+LIBS = ${top_builddir}/auparse/libauparse.la
 AM_CFLAGS = -D_GNU_SOURCE
 bin_PROGRAMS = aulast
 noinst_HEADERS = aulast-llist.h

--- a/tools/aulastlog/Makefile.am
+++ b/tools/aulastlog/Makefile.am
@@ -23,7 +23,7 @@
 CONFIG_CLEAN_FILES = *.loT *.rej *.orig
 EXTRA_DIST = $(man_MANS)
 AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/auparse
-LIBS = -L${top_builddir}/auparse -lauparse
+LIBS = ${top_builddir}/auparse/libauparse.la
 AM_CFLAGS = -D_GNU_SOURCE
 bin_PROGRAMS = aulastlog
 noinst_HEADERS = aulastlog-llist.h

--- a/tools/ausyscall/Makefile.am
+++ b/tools/ausyscall/Makefile.am
@@ -23,7 +23,7 @@
 CONFIG_CLEAN_FILES = *.loT *.rej *.orig
 EXTRA_DIST = $(man_MANS)
 AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/lib
-LIBS = -L${top_builddir}/lib -laudit
+LIBS = ${top_builddir}/lib/libaudit.la
 AM_CFLAGS = -D_GNU_SOURCE
 bin_PROGRAMS = ausyscall
 man_MANS = ausyscall.8

--- a/tools/auvirt/Makefile.am
+++ b/tools/auvirt/Makefile.am
@@ -29,7 +29,7 @@ AM_CPPFLAGS = -I${top_srcdir} \
 		   -I${top_srcdir}/lib \
 		   -I${top_srcdir}/auparse \
 		   -I${top_srcdir}/src
-LIBS = -L${top_builddir}/auparse -lauparse
+LIBS = ${top_builddir}/auparse/libauparse.la
 AM_CFLAGS = -D_GNU_SOURCE
 bin_PROGRAMS = auvirt
 noinst_HEADERS = auvirt-list.h


### PR DESCRIPTION
When building against slibtool (https://dev.midipix.org/cross/slibtool) it fails.
```
rdlibtool --tag=CC --mode=link gcc -fPIE -DPIE -g -D_GNU_SOURCE -Wundef -g -O2 -pie -Wl,-z,relro -Wl,-z,now -o audisp-syslog audisp_syslog-audisp-syslog.o -lcap-ng -L../../../common -laucommon -L../../../auparse -lauparse

rdlibtool: lconf: {.name="libtool"}.
rdlibtool: fdcwd: {.fdcwd=AT_FDCWD, .realpath="/tmp/audit-userspace/audisp/plugins/syslog"}.
rdlibtool: lconf: fstatat(AT_FDCWD,".",...) = 0 {.st_dev = 45, .st_ino = 41159}.
rdlibtool: lconf: openat(AT_FDCWD,"libtool",O_RDONLY,0) = -1 [ENOENT].
rdlibtool: lconf: openat(AT_FDCWD,"../",O_DIRECTORY,0) = 3.
rdlibtool: lconf: fstat(3,...) = 0 {.st_dev = 45, .st_ino = 41100}.
rdlibtool: lconf: openat(3,"libtool",O_RDONLY,0) = -1 [ENOENT].
rdlibtool: lconf: openat(3,"../",O_DIRECTORY,0) = 4.
rdlibtool: lconf: fstat(4,...) = 0 {.st_dev = 45, .st_ino = 41089}.
rdlibtool: lconf: openat(4,"libtool",O_RDONLY,0) = -1 [ENOENT].
rdlibtool: lconf: openat(4,"../",O_DIRECTORY,0) = 3.
rdlibtool: lconf: fstat(3,...) = 0 {.st_dev = 45, .st_ino = 41020}.
rdlibtool: lconf: openat(3,"libtool",O_RDONLY,0) = 4.
rdlibtool: lconf: found "/tmp/audit-userspace/libtool".
rdlibtool: link: gcc audisp_syslog-audisp-syslog.o -fPIE -DPIE -g -D_GNU_SOURCE -Wundef -g -O2 -pie -Wl,-z,relro -Wl,-z,now -lcap-ng -L../../../common/.libs -laucommon -L../../../auparse/.libs -lauparse -o .libs/audisp-syslog
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: warning: libaudit.so.1, needed by ../../../auparse/.libs/libauparse.so, not found (try using -rpath or -rpath-link)
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: ../../../auparse/.libs/libauparse.so: undefined reference to `audit_detect_machine'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: ../../../auparse/.libs/libauparse.so: undefined reference to `audit_msg_type_to_name'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: ../../../auparse/.libs/libauparse.so: undefined reference to `audit_flag_to_name'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: ../../../auparse/.libs/libauparse.so: undefined reference to `audit_elf_to_machine'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: ../../../auparse/.libs/libauparse.so: undefined reference to `audit_name_to_msg_type'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: ../../../auparse/.libs/libauparse.so: undefined reference to `audit_syscall_to_name'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: ../../../auparse/.libs/libauparse.so: undefined reference to `audit_ftype_to_name'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: ../../../auparse/.libs/libauparse.so: undefined reference to `audit_machine_to_name'
/usr/lib/gcc/x86_64-pc-linux-gnu/10.2.0/../../../../x86_64-pc-linux-gnu/bin/ld: ../../../auparse/.libs/libauparse.so: undefined reference to `audit_errno_to_name'
collect2: error: ld returned 1 exit status
rdlibtool: exec error upon slbt_exec_link_create_executable(), line 1614: (see child process error messages).
rdlibtool: < returned to > slbt_exec_link(), line 1934.
make[3]: *** [Makefile:485: audisp-syslog] Error 2
make[3]: Leaving directory '/tmp/audit-userspace/audisp/plugins/syslog'
make[2]: *** [Makefile:413: install-recursive] Error 1
make[2]: Leaving directory '/tmp/audit-userspace/audisp/plugins'
make[1]: *** [Makefile:587: install-recursive] Error 1
make[1]: Leaving directory '/tmp/audit-userspace/audisp'
make: *** [Makefile:466: install-recursive] Error 1
```
This is because the build links several internal dependencies with `-Lfoo -lbar` instead of `foo/libbar.la` as per libtool documentation. Additionally some of these libraries are never built as libtool archives at all.

GNU libtool is far more permissive than slibtool and allows this, but to do this correctly so that both GNU libtool and slibtool can work it needs to link with the libtool archive (`.la`) files instead.

Also please see this gentoo issue: https://bugs.gentoo.org/779529