### PR TITLE
Fix the closing timing of audit_fd

### DIFF
--- a/lib/netlink.c
+++ b/lib/netlink.c
@@ -64,10 +64,10 @@ int audit_open(void)
 	}
 	if (fcntl(fd, F_SETFD, FD_CLOEXEC) == -1) {
 		saved_errno = errno;
-		close(fd);
 		audit_msg(LOG_ERR, 
 			"Error setting audit netlink socket CLOEXEC flag (%s)", 
 			strerror(errno));
+		close(fd);
 		errno = saved_errno;
 		return -1;
 	}


### PR DESCRIPTION
When an error occurs in fcntl(), strerror(errno) is called after close().
If an error occurs in close(), it will overwrite the errno of fcntl().
Therefore, the timing of close() is changed after strerror(errno).