### PR TITLE
Fix the return value of audit_get_reply.3 to -errno

### DIFF
--- a/docs/audit_get_reply.3
+++ b/docs/audit_get_reply.3
@@ -11,7 +11,7 @@ This function gets the next data packet sent on the audit netlink socket. This f
 
 .SH "RETURN VALUE"
 
-This function returns \-1 on error, 0 if error response received, and positive value on success.
+This function returns \-errno on error, 0 if error response received, and positive value on success.
 
 .SH "SEE ALSO"
 


### PR DESCRIPTION
audit_get_reply.3 states that -1 is returned on error, but in implementation it returns -errno.
Fix the return value of audit_get_reply.3 to -errno according to the implementation.