### PR TITLE
Fix the default location for zos-remote.conf

### DIFF
--- a/audisp/plugins/zos-remote/audispd-zos-remote.conf
+++ b/audisp/plugins/zos-remote/audispd-zos-remote.conf
@@ -10,5 +10,5 @@ active = no
 direction = out
 path = /sbin/audispd-zos-remote
 type = always 
-args = /etc/audisp/zos-remote.conf
+args = /etc/audit/zos-remote.conf
 format = string

--- a/docs/zos-remote.conf.5
+++ b/docs/zos-remote.conf.5
@@ -26,7 +26,7 @@ zos\-remote.conf \- the audisp-racf plugin configuration file
 controls the configuration for the
 .BR audispd\-zos\-remote (8)
 Audit dispatcher plugin. The default location for this file is
-.IR /etc/audisp/zos\-remote.conf ,
+.IR /etc/audit/zos\-remote.conf ,
 however, a different file can be specified as the first argument to the
 .B audispd\-zos\-remote
 plugin. See


### PR DESCRIPTION
 All audispd config files have been moved to "/etc/audit" in the commit a5f7baf0917a60cacbd237ba1f1512db63445031.
 The file zos-remote.conf is still configured under /etc/audisp in audispd-zos-remote.conf.