### PR TITLE
Fix not to list own man-page in "SEE ALSO"

### DIFF
--- a/docs/audit_log_user_avc_message.3
+++ b/docs/audit_log_user_avc_message.3
@@ -33,7 +33,7 @@ This function returns \-1 on failure. Examine errno for more info.
 
 .BR audit_log_user_message (3),
 .BR audit_log_acct_message (3),
-.BR audit_log_user_avc_message (3),
+.BR audit_log_user_comm_message (3),
 .BR audit_log_semanage_message (3).
 
 .SH AUTHOR

--- a/docs/auparse_get_milli.3
+++ b/docs/auparse_get_milli.3
@@ -18,7 +18,6 @@ Returns 0 if an error occurs; otherwise, the value of the millisecond portion of
 
 .BR auparse_get_timestamp (3),
 .BR auparse_get_time (3).
-.BR auparse_get_milli (3).
 .BR auparse_get_node (3).
 
 .SH AUTHOR


### PR DESCRIPTION
There is a man-page that references to its own man-page.
Fixed not to refer to own man-page.