### PR TITLE
auditd.service: Restart 'on-failure', ignoring some exit codes

### DIFF
--- a/init.d/auditd.service
+++ b/init.d/auditd.service
@@ -27,6 +27,9 @@ ExecStartPost=-/sbin/augenrules --load
 # By default we don't clear the rules on exit. To enable this, uncomment
 # the next line after copying the file to /etc/systemd/system/auditd.service
 #ExecStopPost=/sbin/auditctl -R /etc/audit/audit-stop.rules
+Restart=on-failure
+# Do not restart for intentional exits. See EXIT CODES section in auditd(8).
+RestartPreventExitStatus=2 4 6
 
 ### Security Settings ###
 MemoryDenyWriteExecute=true


### PR DESCRIPTION
Use `Restart=on-failure` to automatically restart `auditd`. Do not restart for intentional exits. See EXIT CODES section in auditd(8).

See:
- https://www.freedesktop.org/software/systemd/man/systemd.service.html#Restart=
- https://www.freedesktop.org/software/systemd/man/systemd.service.html#RestartPreventExitStatus=

Fixes: https://github.com/linux-audit/audit-userspace/issues/211