### PR TITLE
Security hardening for auditd.service, create augenrules.service

### DIFF
--- a/init.d/Makefile.am
+++ b/init.d/Makefile.am
@@ -26,7 +26,7 @@ EXTRA_DIST = auditd.init auditd.service auditd.sysconfig auditd.conf \
 	auditd.cron libaudit.conf auditd.condrestart \
 	auditd.reload auditd.restart auditd.resume \
 	auditd.rotate auditd.state auditd.stop \
-	audit-stop.rules augenrules
+	audit-stop.rules augenrules augenrules.service
 libconfig = libaudit.conf
 if ENABLE_SYSTEMD
 initdir = /usr/lib/systemd/system
@@ -53,6 +53,7 @@ if ENABLE_SYSTEMD
 	mkdir -p ${DESTDIR}${initdir}
 	mkdir -p ${DESTDIR}${legacydir}
 	$(INSTALL_SCRIPT) -D -m 644 ${srcdir}/auditd.service ${DESTDIR}${initdir}
+	$(INSTALL_SCRIPT) -D -m 644 ${srcdir}/augenrules.service ${DESTDIR}${initdir}
 	$(INSTALL_SCRIPT) -D -m 750 ${srcdir}/auditd.rotate ${DESTDIR}${legacydir}/rotate
 	$(INSTALL_SCRIPT) -D -m 750 ${srcdir}/auditd.resume ${DESTDIR}${legacydir}/resume
 	$(INSTALL_SCRIPT) -D -m 750 ${srcdir}/auditd.reload ${DESTDIR}${legacydir}/reload
@@ -70,6 +71,7 @@ uninstall-hook:
 	rm ${DESTDIR}${sysconfdir}/${libconfig}
 if ENABLE_SYSTEMD
 	rm ${DESTDIR}${initdir}/auditd.service
+	rm ${DESTDIR}${initdir}/augenrules.service
 	rm ${DESTDIR}${legacydir}/rotate
 	rm ${DESTDIR}${legacydir}/resume
 	rm ${DESTDIR}${legacydir}/reload

--- a/init.d/auditd.service
+++ b/init.d/auditd.service
@@ -11,22 +11,22 @@ After=local-fs.target systemd-tmpfiles-setup.service
 Before=sysinit.target shutdown.target
 ##Before=shutdown.target
 Conflicts=shutdown.target
-RefuseManualStop=yes
 ConditionKernelCommandLine=!audit=0
 Documentation=man:auditd(8) https://github.com/linux-audit/audit-documentation
+Requires=augenrules.service
+# This unit clears rules on stop, so make sure that augenrules runs again
+PropagatesStopTo=augenrules.service
 
 [Service]
 Type=forking
 PIDFile=/run/auditd.pid
 ExecStart=/sbin/auditd
-## To not use augenrules, copy this file to /etc/systemd/system/auditd.service
-## and comment/delete the next line and uncomment the auditctl line.
-## NOTE: augenrules expect any rules to be added to /etc/audit/rules.d/
-ExecStartPost=-/sbin/augenrules --load
+## To not use augenrules: copy this file to /etc/systemd/system/auditd.service,
+## uncomment the next line, and comment the Requires=augenrules.service above.
 #ExecStartPost=-/sbin/auditctl -R /etc/audit/audit.rules
-# By default we don't clear the rules on exit. To enable this, uncomment
+# By default we clear the rules on exit. To disable this, comment
 # the next line after copying the file to /etc/systemd/system/auditd.service
-#ExecStopPost=/sbin/auditctl -R /etc/audit/audit-stop.rules
+ExecStopPost=/sbin/auditctl -R /etc/audit/audit-stop.rules
 Restart=on-failure
 # Do not restart for intentional exits. See EXIT CODES section in auditd(8).
 RestartPreventExitStatus=2 4 6
@@ -43,8 +43,6 @@ ProtectHostname=true
 ProtectClock=true
 ProtectKernelTunables=true
 ProtectKernelLogs=true
-# end of automatic additions 
-ReadWritePaths=/etc/audit
 
 [Install]
 WantedBy=multi-user.target

--- a/init.d/auditd.service
+++ b/init.d/auditd.service
@@ -38,6 +38,13 @@ ProtectControlGroups=true
 ProtectKernelModules=true
 ProtectHome=true
 RestrictRealtime=true
+ProtectSystem=full
+ProtectHostname=true
+ProtectClock=true
+ProtectKernelTunables=true
+ProtectKernelLogs=true
+# end of automatic additions 
+ReadWritePaths=/etc/audit
 
 [Install]
 WantedBy=multi-user.target

--- a/init.d/augenrules.service
+++ b/init.d/augenrules.service
@@ -1,0 +1,27 @@
+[Unit]
+Description=auditd rules generation
+After=auditd.service
+Documentation=man:augenrules(8)
+
+[Service]
+Type=oneshot
+## NOTE: augenrules expect any rules to be added to /etc/audit/rules.d/
+ExecStart=/sbin/augenrules --load
+# We need RemainAfterExit=true so augenrules is called again
+# in case auditd.service is restarted.
+RemainAfterExit=true
+
+### Security Settings ###
+MemoryDenyWriteExecute=true
+LockPersonality=true
+ProtectControlGroups=true
+ProtectKernelModules=true
+ProtectHome=true
+RestrictRealtime=true
+ProtectSystem=full
+PrivateDevices=true
+ProtectHostname=true
+ProtectClock=true
+ProtectKernelTunables=true
+ProtectKernelLogs=true
+ReadWritePaths=/etc/audit


### PR DESCRIPTION
As part of [openSUSE's security hardening effort](https://en.opensuse.org/openSUSE:Security_Features#Systemd_hardening_effort), implement some of systemd's measures to auditd.service.

Also split augenrules into a separate service so we can have an exception there for read/write to /etc/audit, since auditd.service doesn't need such access.