### PR TITLE
consider max_log_file == 0 as unlimited

### DIFF
--- a/src/auditd-event.c
+++ b/src/auditd-event.c
@@ -1091,6 +1091,15 @@ static void rotate_logs(unsigned int num_logs, unsigned int keep_logs)
 		return;
 	}
 
+	/* If max_log_file is unset (0 by default), consider it 'unlimited',
+	 * i.e. do not rotate logs, keep appending to log_file.
+	 */
+	if (config->max_log_size == 0) {
+		audit_msg(LOG_NOTICE,
+			"Log rotation disabled, max_log_file is 0 (unlimited), skipping");
+		return;
+	}
+
 	/* Close audit file. fchmod and fchown errors are not fatal because we
 	 * already adjusted log file permissions and ownership when opening the
 	 * log file. */


### PR DESCRIPTION
If config file has, for example:

max_log_file = 0 # or unset
max_log_file_action = ROTATE # or KEEP_LOGS
num_logs = 100

auditd will rotate the logs with a single event on it, sometimes even
with no events at all, creating @num_logs rotated logs on disk.

If both max_log_file and num_logs are 0 or unset, this bug doesn't
happen; a single log file is created and appended to indefinitely.

This patch makes auditd consider that when max_log_file is 0 or
unset in the config file, the log file shall grow unlimitedly, leaving
any size checks and actions for space_left/disk_full, just as the
situation mentioned right above.

Signed-off-by: Enzo Matsumiya <ematsumiya@suse.de>