### PR TITLE
auparse: fix off-by-one issue in path_norm()

### DIFF
--- a/auparse/interpret.c
+++ b/auparse/interpret.c
@@ -895,7 +895,7 @@ static char *path_norm(const char *name)
 		return strdup(name);
 
 	rpath = working;
-	dest = rpath + 1;
+	dest = rpath;
 	rpath_limit = rpath + PATH_MAX;
 
 	for (start = name; *start; start = end) {


### PR DESCRIPTION
When defining dest = rpath + 1, we end up having the first char of
`dest' as NULL -- since `rpath' points to `working', which is a static
buffer.

With the first char as NULL, path_norm() ends up producing an empty string.

This commit fixes the issue reported in this [1] mailing list post.

[1] https://listman.redhat.com/archives/linux-audit/2022-February/018844.html