### PR TITLE
auditswig.i: avoid setter generation for audit_rule_data::buf

### DIFF
--- a/bindings/swig/src/auditswig.i
+++ b/bindings/swig/src/auditswig.i
@@ -39,6 +39,10 @@ signed
 #define __attribute(X) /*nothing*/
 typedef unsigned __u32;
 typedef unsigned uid_t;
+/* Sidestep SWIG's limitation of handling c99 Flexible arrays by not:
+ * generating setters against them: https://github.com/swig/swig/issues/1699
+ */
+%ignore audit_rule_data::buf;
 %include "/usr/include/linux/audit.h"
 #define __extension__ /*nothing*/
 %include <stdint.i>


### PR DESCRIPTION
As it's a flexible array generated code was never safe to use.
With kernel's https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=ed98ea2128b6fd83bce13716edf8f5fe6c47f574
change it's a build failure now:

    audit> audit_wrap.c:5010:15: error: invalid use of flexible array member
    audit>  5010 |     arg1->buf = (char [])(char *)memcpy(malloc((size)*sizeof(char)), (const char *)(arg2), sizeof(char)*(size));
    audit>       |               ^

Let's avoid setter generation entirely.

Closes: https://github.com/linux-audit/audit-userspace/issues/252