### PR TITLE
audisp-remote: fix hang with disk_low_action=suspend

### DIFF
--- a/audisp/plugins/remote/audisp-remote.c
+++ b/audisp/plugins/remote/audisp-remote.c
@@ -619,7 +619,7 @@ int main(int argc, char *argv[])
 
 	// If stdin is a pipe, then flush the queue
 	if (is_pipe(0)) {
-		while (q_queue_length(queue) && transport_ok)
+		while (q_queue_length(queue) && !suspend && transport_ok)
 			send_one(queue);
 	}
 


### PR DESCRIPTION
Bug description:
If auditd.conf has disk_low_action=suspend and the partition where the
log is triggers the disk_low_action, audisp-remote will hang in
infinite loop.

Reproduce:
- enable audisp-remote plugin
- set disk_low_action=suspend in auditd.conf
- fill partition where /var/log/audit is
- wait for disk_low_action to kick in

Results:
audisp-remote keeps running with 100% CPU usage, no further actions from it

Expected results:
audisp-remote is suspended

Fixes: 10dde069d1ac ("Dont look for stop on exit while draining the queue")
Signed-off-by: Enzo Matsumiya <ematsumiya@suse.de>