### PR TITLE
Fix building with Python 3.5

### DIFF
--- a/bindings/python/auparse_python.c
+++ b/bindings/python/auparse_python.c
@@ -28,7 +28,7 @@ auparse_timestamp_compare: because AuEvent calls this via the cmp operator
 
 #if PY_MAJOR_VERSION > 2
 #define IS_PY3K
-#if PY_MINOR_VERSION > 5
+#if PY_MINOR_VERSION >= 5
 #define USE_RICH_COMPARISON
 #endif
 #define MODINITERROR return NULL


### PR DESCRIPTION
Fixes: 9976d2c ("Fix the other instance of PyTypeObject which uses .tp_compare which is now deprecated")

Build error was:
```
DEBUG: ../../../bindings/python/auparse_python.c:231:6: error: 'PyTypeObject' {aka 'struct _typeobject'} has no member named 'tp_compare'<...>
DEBUG:      .tp_compare = AuEvent_compare,
DEBUG:       ^~~~~~~~~~
```