### PR TITLE
Re-implement record field list as a linked list

### DIFF
--- a/auparse/interpret.c
+++ b/auparse/interpret.c
@@ -3144,8 +3144,7 @@ char *auparse_do_interpretation(int type, const idata *id,
 	if (interpretation_list_cnt()) {
 		nvlist_first(&il);
 		if (nvlist_find_name(&il, id->name)) {
-			nvnode* node = &il.array[il.cur];
-			const char *val = node->interp_val;
+			const char *val = nvlist_get_cur_val_interp(&il);
 
 			if (val) {
 				// If we don't know what it is when auditd

--- a/auparse/nvlist.c
+++ b/auparse/nvlist.c
@@ -32,8 +32,8 @@
 void nvlist_create(nvlist *l)
 {
 	if (l) {
-		memset(&l->array[0], 0, sizeof(nvnode) * NFIELDS);
-		l->cur = 0;
+        l->first = NULL;
+		l->cur = NULL;
 		l->cnt = 0;
 		l->record = NULL;
 		l->end = NULL;
@@ -42,10 +42,9 @@ void nvlist_create(nvlist *l)
 
 nvnode *nvlist_next(nvlist *l)
 {
-	// Since cur will be incremented, check for 1 less that total
-	if (l->cnt && l->cur < (l->cnt - 1)) {
-		l->cur++;
-		return &l->array[l->cur];
+	if (l->cur && l->cur->next) {
+		l->cur = l->cur->next;
+		return l->cur;
 	}
 	return NULL;
 }
@@ -53,18 +52,29 @@ nvnode *nvlist_next(nvlist *l)
 // 0 on success and 1 on error
 int nvlist_append(nvlist *l, nvnode *node)
 {
-	// FIXME: on overflow switch to linked list
-	if (l->cnt >= NFIELDS || node->name == NULL)
+	if (node->name == NULL)
 		return 1;
 
-	nvnode *newnode = &l->array[l->cnt];
+	// FIXME: check new pointer here and in other modules...
+	nvnode *newnode = malloc(sizeof(nvnode));
 	newnode->name = node->name;
 	newnode->val = node->val;
 	newnode->interp_val = NULL;
 	newnode->item = l->cnt;
+	newnode->next = NULL;
+
+	// make sure we append to the end
+	if (l->first) {
+		if (l->cur) {
+			while (l->cur->next)
+				l->cur = l->cur->next;
+			l->cur->next = newnode;
+		}
+	} else
+		l->first = newnode;
 
 	// make newnode current
-	l->cur = l->cnt;
+	l->cur = newnode;
 	l->cnt++;
 	return 0;
 }
@@ -74,39 +84,50 @@ int nvlist_append(nvlist *l, nvnode *node)
  */
 void nvlist_interp_fixup(nvlist *l)
 {
-	nvnode* node = &l->array[l->cur];
-	node->interp_val = node->val;
-	node->val = NULL;
+	nvnode* node = l->cur;
+	if (node) {
+		node->interp_val = node->val;
+		node->val = NULL;
+	}
 }
 
 nvnode *nvlist_goto_rec(nvlist *l, unsigned int i)
 {
-	if (i <= l->cnt) {
-		l->cur = i;
-		return &l->array[l->cur];
-	}
+	nvnode *node = l->first;
+
+	if (!node)
+		return NULL;
+
+	int n = 0;
+	do {
+		if (n == i) {
+			l->cur = node;
+			return node;
+		}
+		node = node->next;
+		n++;
+	} while (node);
+
 	return NULL;
 }
 
 /*
- * This function will start at current index and scan for a name
+ * This function will start at current node and scan for a name
  */
 int nvlist_find_name(nvlist *l, const char *name)
 {
-	unsigned int i = l->cur;
-	register nvnode *node;
+	register nvnode *node = l->cur;
 
-	if (l->cnt == 0)
+	if (!node)
 		return 0;
 
 	do {
-		node = &l->array[i];
 		if (node->name && strcmp(node->name, name) == 0) {
-			l->cur = i;
+			l->cur = node;
 			return 1;
 		}
-		i++;
-	} while (i < l->cnt);
+		node = node->next;
+	} while (node);
 	return 0;
 }
 
@@ -114,16 +135,19 @@ extern int interp_adjust_type(int rtype, const char *name, const char *val);
 int nvlist_get_cur_type(rnode *r)
 {
 	nvlist *l = &r->nv;
-	nvnode *node = &l->array[l->cur];
-	return auparse_interp_adjust_type(r->type, node->name, node->val);
+	nvnode *node = l->cur;
+    if (node)
+        return auparse_interp_adjust_type(r->type, node->name, node->val);
+    else
+        return AUPARSE_TYPE_UNCLASSIFIED;
 }
 
 const char *nvlist_interp_cur_val(rnode *r, auparse_esc_t escape_mode)
 {
 	nvlist *l = &r->nv;
-	if (l->cnt == 0)
+	nvnode *node = l->cur;
+	if (!node)
 		return NULL;
-	nvnode *node = &l->array[l->cur];
 	if (node->interp_val)
 		return node->interp_val;
 	return do_interpret(r, escape_mode);
@@ -142,14 +166,9 @@ static inline int not_in_rec_buf(nvlist *l, const char *ptr)
 // free_interp does not apply to thing coming from interpretation_list
 void nvlist_clear(nvlist *l, int free_interp)
 {
-	unsigned int i = 0;
-	register nvnode *current;
+	register nvnode *current = l->first;
 
-	if (l->cnt == 0)
-		return;
-
-	while (i < l->cnt) {
-		current = &l->array[i];
+	while (current) {
 		if (free_interp) {
 			free(current->interp_val);
 			// A couple items are not in parsed up list.
@@ -161,11 +180,14 @@ void nvlist_clear(nvlist *l, int free_interp)
 				free(current->name);
 			}
 		}
-		i++;
+		nvnode *next = current->next;
+		free(current);
+		current = next;
 	}
 	free((void *)l->record);
 	l->record = NULL;
 	l->end = NULL;
-	l->cur = 0;
+	l->first = NULL;
+	l->cur = NULL;
 	l->cnt = 0;
 }

--- a/auparse/nvlist.h
+++ b/auparse/nvlist.h
@@ -32,15 +32,15 @@
 
 
 static inline unsigned int nvlist_get_cnt(nvlist *l) { return l->cnt; }
-static inline void nvlist_first(nvlist *l) { l->cur = 0; }
+static inline void nvlist_first(nvlist *l) { l->cur = l->first; }
 static inline nvnode *nvlist_get_cur(nvlist *l)
-	{ return &l->array[l->cur]; }
+	{ return l->cur; }
 static inline const char *nvlist_get_cur_name(nvlist *l)
-	{if (l->cnt) { nvnode *node = &l->array[l->cur]; return node->name; } else return NULL;}
+	{if (l->cur) { return l->cur->name; } else return NULL;}
 static inline const char *nvlist_get_cur_val(nvlist *l)
-	{if (l->cnt) { nvnode *node = &l->array[l->cur]; return node->val; } else return NULL;}
+	{if (l->cur) { return l->cur->val; } else return NULL;}
 static inline const char *nvlist_get_cur_val_interp(nvlist *l)
-	{if (l->cnt) { nvnode *node = &l->array[l->cur]; return node->interp_val; } else return NULL;}
+	{if (l->cur) { return l->cur->interp_val; } else return NULL;}
 
 AUDIT_HIDDEN_START
 

--- a/auparse/rnode.h
+++ b/auparse/rnode.h
@@ -23,8 +23,6 @@
 #ifndef RNODE_HEADER
 #define RNODE_HEADER
 
-#define NFIELDS 36
-
 /* This is the data node of the fields list. Any data elements that are
  * per field goes here. */
 typedef struct _nvnode{
@@ -32,12 +30,13 @@ typedef struct _nvnode{
   char *val;            // The value field
   char *interp_val;     // The value field interpreted
   unsigned int item;    // Which item of the same event
+  struct _nvnode *next; // Next data node or NULL
 } nvnode;
 
 /* This is the field list head. */
 typedef struct {
-  nvnode array[NFIELDS];// array of fields
-  unsigned int cur;     // Index to current node
+  nvnode *first;    // First data node
+  nvnode *cur;      // Current data node
   unsigned int cnt;     // How many items in this list
   char *record;		// Holds the parsed up record
   char *end;		// End of the parsed up record


### PR DESCRIPTION
```
int nvlist_append(nvlist *l, nvnode *node)
{
	// FIXME: on overflow switch to linked list
	if (l->cnt >= NFIELDS || node->name == NULL)
	if (node->name == NULL)
		return 1;
    ...
}
```

Okay, let's switch as we have an overflow with `EXECVE` records
containing hundreds of arguments.

Signed-off-by: Paul Wolneykien <manowar@altlinux.org>