### PR TITLE
fix: use normal permissions for augenrules

### DIFF
--- a/init.d/Makefile.am
+++ b/init.d/Makefile.am
@@ -65,7 +65,6 @@ if ENABLE_SYSTEMD
 else
 	$(INSTALL_SCRIPT) -D ${srcdir}/auditd.init ${DESTDIR}${initdir}/auditd
 endif
-	chmod 0750 $(DESTDIR)$(sbindir)/augenrules
 
 
 uninstall-hook:


### PR DESCRIPTION
It is not necessary to restrict the permissions of `augenrules` to `0750`. If the calling user doesn't have sufficient permissions, its operation fails anyway. For security, the current restrictive permissions for the configuration files in `/etc/audit` should be enough.