### PR TITLE
fix: error message did not mention exe type

### DIFF
--- a/lib/errormsg.h
+++ b/lib/errormsg.h
@@ -86,7 +86,7 @@ static const struct msg_tab err_msgtab[] = {
     { -EAU_MSGTYPEEXCLUDEUSER,	0, "msgtype field can only be used with exclude or user filter list" },
     { -EAU_UPGRADEFAIL,		0, "Failed upgrading rule" },
     { -EAU_STRTOOLONG,		0, "String value too long" },
-    { -EAU_MSGTYPECREDEXCLUDE,	0, "Only msgtype, *uid, *gid, pid, and subj* fields can be used with exclude filter" },
+    { -EAU_MSGTYPECREDEXCLUDE,	0, "Only msgtype, *uid, *gid, pid, exe and subj* fields can be used with exclude filter" },
     { -EAU_OPEQNOTEQ,		1, "only takes = or != operators" },
     { -EAU_PERMRWXA,		0, "Permission can only contain  \'rwxa\'" },
     { -EAU_ERRUNKNOWN,		2, "-F unknown errno -"},


### PR DESCRIPTION
This PR is for fixing a wrong error message regarding the `exclude` filter.

If I have a rule like this:

```
-A exclude,always -F exe=/usr/bin/sudo -F success=1
```

When I run `augenctrl --load`, I get this error message:

```
Only msgtype, *uid, *gid, pid, and subj* fields can be used with exclude filter
```

However, it is not accurate. The man page says:

```
Events can be excluded  by  process  ID,  user  ID,
group  ID,  login  user  ID, message type, subject context, or exe‐
cutable name.
```

I tried this rule

```
-A exclude,always -F exe=/usr/bin/sudo
```

And it works.