### PR TITLE
Replacing problematic terms

### DIFF
--- a/audisp/plugins/ids/ids_config.h
+++ b/audisp/plugins/ids/ids_config.h
@@ -37,7 +37,7 @@
 // sysctls, selinux booleans
 // update specific rpm, all rpms
 // restart service
-// drop service timed <- need to whitelist these
+// drop service timed <- need to allowlist these
 
 // System terminations
 // Drop network timed

--- a/src/ausearch-llist.h
+++ b/src/ausearch-llist.h
@@ -97,7 +97,7 @@ typedef struct {
 
 			// Data we add as 1 per event
   event e;		// event - time & serial number
-  search_items s;	// items in master rec that are searchable
+  search_items s;	// items in main rec that are searchable
   int fmt;		// The event's format (raw, enriched)
 } llist;
 


### PR DESCRIPTION
Hello,

we use some internal tools to detect problematic language (master, slave, black-list, white-list, etc...) inside the project. This change replaces it in the comments.