### PR TITLE
Add context for UIDs and GIDs in audit event

### DIFF
--- a/auparse/interpret.c
+++ b/auparse/interpret.c
@@ -3197,8 +3197,17 @@ char *auparse_do_interpretation(int type, const idata *id,
 
 	// Check the interpretations list first
 	if (interpretation_list_cnt()) {
+		int found = 0;
+
 		nvlist_first(&il);
-		if (nvlist_find_name(&il, id->name)) {
+		if (type == AUPARSE_TYPE_UID ||
+			type == AUPARSE_TYPE_GID) {
+			found = nvlist_find_name_ex(&il, id->name, id->val);
+		} else {
+			found = nvlist_find_name(&il, id->name);
+		}
+
+		if (found) {
 			nvnode* node = &il.array[il.cur];
 			const char *val = node->interp_val;
 

--- a/auparse/nvlist.c
+++ b/auparse/nvlist.c
@@ -24,6 +24,7 @@
 #include "config.h"
 #include <stdlib.h>
 #include <string.h>
+#include <stdio.h>
 #include "nvlist.h"
 #include "interpret.h"
 #include "auparse-idata.h"
@@ -122,6 +123,19 @@ int nvlist_find_name(nvlist *l, const char *name)
 	} while (i < l->cnt);
 	return 0;
 }
+
+/*
+ * Like above, but use original value for key to search
+ */
+#define NAME_SIZE 64
+int nvlist_find_name_ex(nvlist *l, const char *name, const char *val)
+{
+	char key[NAME_SIZE] = { 0 };
+
+	snprintf(key, NAME_SIZE, "%s%s", name, val);
+	return nvlist_find_name(l, key);
+}
+
 
 extern int interp_adjust_type(int rtype, const char *name, const char *val);
 int nvlist_get_cur_type(rnode *r)

--- a/auparse/nvlist.h
+++ b/auparse/nvlist.h
@@ -56,6 +56,7 @@ void nvlist_interp_fixup(nvlist *l);
 nvnode *nvlist_goto_rec(nvlist *l, unsigned int i);
 /* Given a name, find that record */
 int nvlist_find_name(nvlist *l, const char *name);
+int nvlist_find_name_ex(nvlist *l, const char *name, const char *val);
 
 AUDIT_HIDDEN_END
 

--- a/src/auditd-event.c
+++ b/src/auditd-event.c
@@ -333,6 +333,7 @@ static int add_simple_field(auparse_state_t *au, size_t len_left, int encode)
 	size_t nlen, vlen, tlen;
 	unsigned int i;
 	int num;
+	int field_type = AUPARSE_TYPE_UNCLASSIFIED;
 
 	// prepare field name
 	i = 0;
@@ -344,6 +345,22 @@ static int add_simple_field(auparse_state_t *au, size_t len_left, int encode)
 	}
 	field_name[i] = 0;
 	nlen = i;
+
+	// get field type for event and add context for interpreted value
+	field_type = auparse_get_field_type(au);
+	if (field_type == AUPARSE_TYPE_UID ||
+		field_type == AUPARSE_TYPE_GID) {
+		char *val = auparse_get_field_str(au);
+
+		i = nlen;
+		while (*val && i < (NAME_SIZE - 1)) {
+			field_name[i] = *val;
+			i++;
+			val++;
+		}
+		field_name[i] = 0;
+		nlen = i;
+	}
 
 	// get the translated value
 	value = auparse_interpret_field(au);


### PR DESCRIPTION
I found a problem when parsing audit events via auparse in interpert mode.

Suppose we have an registered event in audit.log:

<pre>
type=ANOM_LOGIN_FAILURES msg=audit(1680165235.344:750): pid=16619 uid=0 auid=1000 ses=7 msg='pam_faillock uid=1003  exe="/usr/bin/login" hostname=arm1 addr=? terminal=pts/2 res=success'<0x1d>UID="root" AUID="administrator" UID="testuser-16293"
</pre>

Interpreted values for this event are registered well, but logic of parse events translates field `uid=1003 ` to `uid=root`, that is error. So, it's error due to cache logic in `static const char *lookup_uid(const char *field, uid_t uid)`. Logic of this function uses cache for returning already interpreted value, but can not used for events, that contains different values for one field (in our case `UID` - see row 212-214).

So, this patch forms interpreted keys as concatenation of user attribute (`UID` or `GID` and real value for it, e.g. `1000`, `1001`). So, auparse will use those keys for good replacement UID and GID fields via interpeted values.

