### PR TITLE
Configure fix

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -157,7 +157,7 @@ else
 	if test "x$use_python" = xyes ; then
 		AC_MSG_ERROR([Python explicitly requested and python headers were not found])
 	else
-		AC_MSG_WARN("Python headers not found - python bindings will not be made")
+		AC_MSG_WARN(Python headers not found - python bindings will not be made)
 	fi
 fi
 fi
@@ -232,7 +232,7 @@ else
 	if test "x$use_golang" = xyes ; then
 		AC_MSG_ERROR([Go language explicitly requested and program not found])
 	else
-		AC_MSG_WARN("Go not found - go bindings will not be made")
+		AC_MSG_WARN(Go not found - go bindings will not be made)
 	fi
     ])
 fi

--- a/configure.ac
+++ b/configure.ac
@@ -209,6 +209,11 @@ else
 fi
 AM_CONDITIONAL(USE_PYTHON3, test ${use_python3} = "yes")
 
+if test "x$use_python" = "xyes" || test "x$use_python3" = "xyes" ; then
+	AC_CHECK_PROG([SWIG],[swig],[swig], [no])
+	AS_IF([test x"$SWIG" == x"no"], [AC_MSG_ERROR([Please install swig before configuring (required by python/python3).])])
+fi
+
 withval=""
 AC_MSG_CHECKING(whether to create Go language bindings)
 AC_ARG_WITH(golang,


### PR DESCRIPTION
The PR attempts to fix two issues:

c561c7b47189fc04f2b04c7d184e5ba70deebe2c - Add a check for the swig program if either --with-python or --with-python3 is specified. In case one of the above written configuration options was specifed and the swig program was not present, compilation failed due to not having swig installed, e.g.:
```
Making all in python3
make[4]: Entering directory '/home/alakatos/github/audit-userspace/bindings/swig/python3'
swig -o audit_wrap.c -python -py3 -modern -I. -I../../.. -I../../../lib -I/usr/include/python3.11 -I/usr/include/python3.11 ./../src/auditswig.i 
make[4]: swig: No such file or directory
make[4]: *** [Makefile:786: audit_wrap.c] Error 127
make[4]: Leaving directory '/home/alakatos/github/audit-userspace/bindings/swig/python3'
make[3]: *** [Makefile:419: all-recursive] Error 1
make[3]: Leaving directory '/home/alakatos/github/audit-userspace/bindings/swig'
make[2]: *** [Makefile:416: all-recursive] Error 1
make[2]: Leaving directory '/home/alakatos/github/audit-userspace/bindings'
make[1]: *** [Makefile:473: all-recursive] Error 1
make[1]: Leaving directory '/home/alakatos/github/audit-userspace'
make: *** [Makefile:405: all] Error 2
```

cb1dbc7d28fb1271effc6ea16de39f4164d7894e - Remove unnecessary double quotation mark from configure.ac. Some text editors do not expect a quotation mark in AC_MSG_ERROR and in similar macros. Due to that, syntax highlighting is ruined over the rest of the file. I know it's not a problem on the audit user space side,