### PR TITLE
Check for AF_UNIX unnamed sockets

### DIFF
--- a/auparse/interpret.c
+++ b/auparse/interpret.c
@@ -1235,9 +1235,10 @@ static const char *print_sockaddr(const char *val)
         switch (saddr->sa_family) {
                 case AF_LOCAL:
 			if (slen < 4) {
-				rc = asprintf(&out,
-				    "{ saddr_fam=%s sockaddr len too short }",
-							str);
+				rc = asprintf(&out, "{ saddr_fam=%s %s }", str,
+				    slen == sizeof(saddr->sa_family) ?
+				    "unnamed socket" : // ignore sun_path
+				    "sockaddr len too short");
 				break;
 			} else {
                                 const struct sockaddr_un *un =

--- a/src/ausearch-parse.c
+++ b/src/ausearch-parse.c
@@ -1706,20 +1706,22 @@ static int parse_sockaddr(const lnode *n, search_items *s)
 				}
 				len = sizeof(struct sockaddr_in6);
 			} else if (saddr->sa_family == AF_UNIX) {
-				if (len < 4) {
-					fprintf(stderr,
-						"sun_path len too short\n");
-					return 3;
-				}
 				struct sockaddr_un *un =
 					(struct sockaddr_un *)saddr;
+				if (len != sizeof(saddr->sa_family) &&
+				    len < 4) {
+					fprintf(stderr,
+						"sun_path len too short (%d)\n",
+						len);
+					return 4;
+				}
 				if (event_filename) {
 					if (!s->filename) {
 						//create
 						s->filename =
 							malloc(sizeof(slist));
 						if (s->filename == NULL)
-							return 4;
+							return 5;
 						slist_create(s->filename);
 					}
 					if (s->filename) {
@@ -1728,9 +1730,12 @@ static int parse_sockaddr(const lnode *n, search_items *s)
 						if (un->sun_path[0])
 						    sn.str =
 							strdup(un->sun_path);
-						else
+						else if (un->sun_path[1])
 						    sn.str =
 							strdup(un->sun_path+1);
+						else
+							return 6;
+
 						sn.key = NULL;
 						sn.hits = 1;
 						slist_append(s->filename, &sn);


### PR DESCRIPTION
According to `man 7 unix`, an unnamed (or anonymous) AF_UNIX socket will have the following properties:

- its address length will be sizeof(sa_family_t)
- sun_family is AF_LOCAL/AF_UNIX (0x1) (obviously, but see below)
- sun_path must not be inspected (empirical evidence suggests sun_path[0] is 0 most of the time though)

Thus, the hex representation of such sockaddr_un is '0100'.  Which is observable as "saddr=0100" in SOCKADDR messages, or "len too short" when interpret flag '-i' is passed.

Example error messages:
```
# aureport -x --summary

Executable Summary Report
=================================
total  file
=================================
sun_path len too short
sun_path len too short
...
sun_path len too short
sun_path len too short
9426  /usr/bin/grep
7070  /usr/sbin/nmbd
2461  /usr/bin/rm
...
# ausearch -m SOCKADDR
...
type=SOCKADDR msg=audit(1681493602.806:85518): saddr=0100
...
# ausearch -m SOCKADDR -i
...
type=SOCKADDR msg=audit(04/14/2023 14:20:54.930:82007) : saddr={ saddr_fam=local sockaddr len too short }
...
```

This commit changes the interpreted message for unnamed/anonymous sockets, and make sure to not return an error if so.

Also, while at it, check if sun_path[1] is valid for abstract sockets cases before trying to strdup() it.