### PR TITLE
Provide meaningful error message when executing auditctl with wrong params

### DIFF
--- a/src/auditctl.c
+++ b/src/auditctl.c
@@ -1494,6 +1494,16 @@ int main(int argc, char *argv[])
 		}
 	}
 	retval = handle_request(retval);
+	if (retval == -1) {
+		if (errno != ECONNREFUSED)
+			audit_msg(LOG_ERR,
+				"There was an error while processing parameters");
+		else {
+			audit_msg(LOG_ERR,
+				"The audit system is disabled");
+			return 0;
+		}
+	}
 	free(rule_new);
 	return retval;
 }


### PR DESCRIPTION
In case ```auditctl``` is executed with args that do not start with the '-' character, no information is displayed to the user. It can be reproduced by e.g.: ```auditctl something non existing params```.

In case rules are loaded from a file, this was already handled correctly. See https://github.com/linux-audit/audit-userspace/blob/master/src/auditctl.c#L1401