### PR TITLE
Update ausearch.8 to include common example

### DIFF
--- a/docs/ausearch.8
+++ b/docs/ausearch.8
@@ -233,6 +233,11 @@ The boot time option is a convenience function and has limitations. The time it 
 
 date -d "`cut \-f1 \-d. /proc/uptime` seconds ago"
 
+.SH EXAMPLE
+.nf
+Check the SELinux log for any denials today
+# ausearch \-i \-m avc \-ts today
+
 .SH "SEE ALSO"
 .BR auditd (8),
 .BR auditd.conf (5),


### PR DESCRIPTION
This patch adds an example to ausearch man page for checking denials today, this is a common use for people visiting the man page.