### PR TITLE
Replace __attribute_malloc__ with __attribute__((__malloc__))

### DIFF
--- a/auparse/auparse.h
+++ b/auparse/auparse.h
@@ -32,6 +32,9 @@
 # define __attr_dealloc(dealloc, argno)
 # define __attr_dealloc_free
 #endif
+#ifndef __attribute_malloc__
+#  define __attribute_malloc__
+#endif
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
__attribute_malloc__ is not available on musl

Fixes
| ../../git/auparse/auparse.h:54:2: error: expected function body after function declarator
|         __attribute_malloc__ __attr_dealloc (auparse_destroy, 1);
|         ^

Downloaded from https://cgit.openembedded.org/meta-openembedded/tree/meta-oe/recipes-security/audit/audit/0001-Replace-__attribute_malloc__-with-__attribute__-__ma.patch