### PR TITLE
Fix the error found by clang-tidy

### DIFF
--- a/src/auditd-reconfig.c
+++ b/src/auditd-reconfig.c
@@ -60,7 +60,7 @@ int start_config_manager(struct auditd_event *e)
 			PTHREAD_CREATE_DETACHED);
 
 	        if (pthread_create(&config_thread, &detached,
-		                config_thread_main, e) < 0) {
+		                config_thread_main, e) > 0) {
 			audit_msg(LOG_ERR,
 			"Couldn't create config thread, no config changes");
 			free(e);


### PR DESCRIPTION
auditd-reconfig.c: In function 'start_config_manager': auditd-reconfig.c:63:42: warning: the comparison always evaluates to false because pthread_create always returns non-negative values