### PR TITLE
audisp/af_unix.conf: Update default config values

### DIFF
--- a/audisp/plugins/af_unix/af_unix.conf
+++ b/audisp/plugins/af_unix/af_unix.conf
@@ -1,4 +1,3 @@
-
 # This file controls the configuration of the
 # af_unix socket plugin. It simply takes events
 # and writes them to a unix domain socket. This
@@ -7,8 +6,7 @@
 
 active = no
 direction = out
-path = builtin_af_unix
-type = builtin 
+path = /sbin/audisp-af_unix
+type = always
 args = 0640 /var/run/audispd_events
 format = string
-


### PR DESCRIPTION
For `path = builtin_af_unix`, fixes:
```
auditd[981]: Option builtin_af_unix line 10 is obsolete - using /sbin/audisp-af_unix
```
See: https://github.com/linux-audit/audit-userspace/blob/2cf5c2e0f72e5977b1fcbb136d084a041d06e4fd/audisp/audispd-pconfig.c#L397

For `type = builtin`, fixes:
```
auditd[981]: Option builtin line 11 is obsolete - update it
```
See: https://github.com/linux-audit/audit-userspace/blob/2cf5c2e0f72e5977b1fcbb136d084a041d06e4fd/audisp/audispd-pconfig.c#L432