### PR TITLE
delete af_unix.conf in audit package

### DIFF
--- a/audit.spec
+++ b/audit.spec
@@ -231,7 +231,6 @@ fi
 %ghost %config(noreplace) %attr(640,root,root) /etc/audit/rules.d/audit.rules
 %ghost %config(noreplace) %attr(640,root,root) /etc/audit/audit.rules
 %config(noreplace) %attr(640,root,root) /etc/audit/audit-stop.rules
-%config(noreplace) %attr(640,root,root) /etc/audit/plugins.d/af_unix.conf
 
 %files -n audispd-plugins
 %config(noreplace) %attr(640,root,root) /etc/audit/plugins.d/audispd-zos-remote.conf


### PR DESCRIPTION
I found that the af_unix.conf does not need to exist in the main package. And the file is already in the audispd-plugins package.