### PR TITLE
ausearch: do not use built-in logs when --input is specified

### DIFF
--- a/src/ausearch.c
+++ b/src/ausearch.c
@@ -109,9 +109,20 @@ int main(int argc, char *argv[])
 	(void) umask( umask( 077 ) | 027 );
 
 	/* Load config so we know where logs are and eoe_timeout */
-	if (load_config(&config, TEST_SEARCH))
-	        fprintf(stderr, "NOTE - using built-in logs: %s\n",
+	if (load_config(&config, TEST_SEARCH)) {
+
+		/* Config was not loaded successfully,
+		 * so we are using the default config values
+		 */
+		fprintf(stderr, "NOTE - using built-in end_of_event_timeout: %lu\n",
+			config.end_of_event_timeout);
+
+		/* Using built-in logs when --input was not given */
+		if (user_file == NULL) {
+			fprintf(stderr, "NOTE - using built-in logs: %s\n",
 				config.log_file);
+		}
+	}
 
 	/* Set timeout from the config file */
 	lol_set_eoe_timeout((time_t)config.end_of_event_timeout);


### PR DESCRIPTION
When processing a file using ```ausearch -if file_name``` as non-root user, the following is displayed:
```
$ ausearch -if ./test
Error opening config file (Permission denied)
NOTE - using built-in logs: /var/log/audit/audit.log
<no matches>
```

With patch applied:
```
Error opening config file (Permission denied)
NOTE - using built-in end_of_event_timeout: 2
<no matches>
```

The behavior is not changed, but correct information about configuration options are displayed to the user.
In case you are not able to view the config file, ```end_of_event_timeout``` can't be queried.