### PR TITLE
Make session id consistently signed

### DIFF
--- a/src/aureport-options.c
+++ b/src/aureport-options.c
@@ -61,7 +61,8 @@ const char *event_uuid = NULL;
 const char *event_vmname = NULL;
 long long event_exit = 0;
 int event_exit_is_set = 0;
-int event_ppid = -1, event_session_id = -2;
+pid_t event_ppid = -1;
+uint32_t event_session_id = -2;
 int event_debug = 0, event_machine = -1;
 time_t	arg_eoe_timeout = (time_t)0;
 

--- a/src/ausearch-options.c
+++ b/src/ausearch-options.c
@@ -895,19 +895,21 @@ int check_params(int count, char *vars[])
 			size_t len = strlen(optarg);
 			if (isdigit(optarg[0])) {
 				errno = 0;
-				event_session_id = strtoul(optarg,NULL,10);
-				if (errno)
+				unsigned long optval = strtoul(optarg,NULL,10);
+				if (errno || optval >= (1ul << 32))
 					retval = -1;
+				event_session_id = optval;
 				c++;
                         } else if (len >= 2 && *(optarg)=='-' &&
                                                 (isdigit(optarg[1]))) {
 				errno = 0;
-                                event_session_id = strtoul(optarg, NULL, 0);
-				if (errno) {
+				long optval = strtol(optarg, NULL, 0);
+				if (errno || optval < INT_MIN || optval > INT_MAX) {
 					retval = -1;
 					fprintf(stderr, "Error converting %s\n",
 						optarg);
 				}
+				event_session_id = optval;
 				c++;
 			} else {
 				fprintf(stderr,


### PR DESCRIPTION
This fixes type-conflicting definitions and declarations.

Reported by CBMC's goto-cc compiler, which performs type-aware linking.

I should add that I am somewhat unsure about a change introduced in 1a0bfcc9a449: it parsed negative session ids with base `0`, which would suggest that inputs must be base 16 (but only in the negative case)?!