### PR TITLE
Fix misspellings

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -30,7 +30,7 @@
 - Add user friendly keywords for signals to auditctl
 - In ausearch, parse up URINGOP and DM_CTRL records
 - Harden auparse to better handle corrupt logs
-- Fix a CFLAGS propogation problem in the common directory
+- Fix a CFLAGS propagation problem in the common directory
 - Move the audispd af_unix plugin to a standalone program
 
 3.1

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ CROSS COMPILING
 Cross compiling is not supported. The audit system builds native binaries at
 build time and uses those to create sorted btrees for fast lookup during
 event processing and reporting. To enable cross compiling, those binaries
-would need to be rewritten in python or another scripting langauge. No one is
+would need to be rewritten in python or another scripting language. No one is
 currently working on that.
 
 OVERVIEW
@@ -81,7 +81,7 @@ Almost all Security Standards are concerned about what happens when logging spac
 
 To get an accurate reading, the audit daemon should log to a disk partition that is reserved only for the audit daemon. This way someone using the logger command can't suddenly fill up the audit space and trigger an admin defined action. It is recommended to set aside a partition, /var/log/audit, for use by the audit daemon. The size of which depends on your audit retention policy.
 
-The audit daemon is started by systemd. Some people run the "systemd-analyze security" command. It tells you all sorts of things to do to protect your system from auditd. However, doing the things it suggests places auditd in namespaces. When that happens, the audit rules may not trigger correctly and auditd may not be able to access trusted databases. The audit service files are the result of trial and error based on well intentioned patchs gone wrong. You can lock it down more, but you probably will break something.
+The audit daemon is started by systemd. Some people run the "systemd-analyze security" command. It tells you all sorts of things to do to protect your system from auditd. However, doing the things it suggests places auditd in namespaces. When that happens, the audit rules may not trigger correctly and auditd may not be able to access trusted databases. The audit service files are the result of trial and error based on well intentioned patches gone wrong. You can lock it down more, but you probably will break something.
 
 RULES
 -----
@@ -195,7 +195,7 @@ auditctl -s
 
 This outputs some basic information such as the kernel backlog size, the current backlog, and how many events have been lost. The backlog size is the size of the queue in records that the kernel can hold records waiting for auditd to collect them. This should be around 8k or larger for a system that really does auditing. If you use the audit system to casually collect SELinux AVC's, then you can go lower to something like 256.
 
-The current backlog tells you how many events are awaiting delivery to auditd at that instant. This number should normally be low - less than 10. If this is getting bigger and approaching the backlog limit in size, then you have a problem to look into. Either you are generating too many events or an auditd plugin is taking too long to dequeue records. The auditd deamon is very fast at writing records to disk and can handle thousands per second.
+The current backlog tells you how many events are awaiting delivery to auditd at that instant. This number should normally be low - less than 10. If this is getting bigger and approaching the backlog limit in size, then you have a problem to look into. Either you are generating too many events or an auditd plugin is taking too long to dequeue records. The auditd daemon is very fast at writing records to disk and can handle thousands per second.
 
 Another way to check performance is to use
 
@@ -231,7 +231,7 @@ This command causes auditd to dump its internal metrics to /var/run/auditd.state
 
 AUPARSE
 -------
-The auparse library is available to allow one to create custom reporting applications. The library is patterned after a dbase or foxpro database library and hass the following categories of functions:
+The auparse library is available to allow one to create custom reporting applications. The library is patterned after a dbase or foxpro database library and has the following categories of functions:
 
 - General functions that affect operation of the library
 - Functions that traverse events

--- a/audisp/plugins/ids/README.md
+++ b/audisp/plugins/ids/README.md
@@ -1,6 +1,6 @@
 This is an experimental Intrusion Detection System (IDS) plugin. It's goal
 is to either identify or react to suspicious activity. This is a work in
-progress and is subject to either be completed or dropped in it's entirity
+progress and is subject to either be completed or dropped in it's entirety
 at its author's descretion.
 
 So, if you would like to test it and report issues or even contribute code

--- a/audisp/plugins/ids/timer-services.c
+++ b/audisp/plugins/ids/timer-services.c
@@ -33,7 +33,7 @@
 
 static nvlist jobs;
 static time_t now;
-// Something to think about, jobs should probably be peristent so that
+// Something to think about, jobs should probably be persistent so that
 // we can resume them after starting back up.
 
 void init_timer_services(void)

--- a/audisp/plugins/remote/audisp-remote.8
+++ b/audisp/plugins/remote/audisp-remote.8
@@ -4,7 +4,7 @@ audisp-remote \- plugin for remote logging
 .SH SYNOPSIS
 .B audisp-remote
 .SH DESCRIPTION
-\fBaudisp-remote\fP is a plugin for the audit event dispatcher that preforms remote logging to an aggregate logging server.
+\fBaudisp-remote\fP is a plugin for the audit event dispatcher that performs remote logging to an aggregate logging server.
 
 .SH TIPS
 If you are aggregating multiple machines, you should edit auditd.conf to set the name_format to something meaningful and the log_format to enriched. This way you can tell where the event came from and have the user name and groups resolved locally before it is sent off of the machine.

--- a/audisp/plugins/remote/audisp-remote.c
+++ b/audisp/plugins/remote/audisp-remote.c
@@ -545,7 +545,7 @@ int main(int argc, char *argv[])
 			continue; // If here, we had some kind of problem
 
 		if ((config.heartbeat_timeout > 0) && n == 0 && !remote_ended) {
-			/* We attempt a hearbeat if select fails, which
+			/* We attempt a heartbeat if select fails, which
 			 * may give us more heartbeats than we need. This
 			 * is safer than too few heartbeats.  */
 			if (config.format == F_MANAGED) {
@@ -1124,7 +1124,7 @@ static int init_sock(void)
 		setsockopt(sock, SOL_SOCKET, SO_REUSEADDR,
 					(char *)&one, sizeof (int));
 
-		// If we are binding, resolve somethihng relative to
+		// If we are binding, resolve something relative to
 		// the address of the aggregating server
 		if (config.local_port != 0) {
 			struct addrinfo *ai2;

--- a/audisp/plugins/statsd/audisp-statsd.c
+++ b/audisp/plugins/statsd/audisp-statsd.c
@@ -78,7 +78,7 @@ static char msg[MAX_AUDIT_MESSAGE_LENGTH + 1];
 static struct daemon_config d;
 static struct audit_report r;
 
-/* Local function protoypes */
+/* Local function prototypes */
 static void handle_event(auparse_state_t *au, auparse_cb_event_t cb_event_type,
 			 void *user_data);
 
@@ -115,7 +115,7 @@ static char *get_line(FILE *f, char *buf, size_t len)
 }
 
 /*
- * Load the plugin's configuration. Returns 1 on failure and 0 on sucess.
+ * Load the plugin's configuration. Returns 1 on failure and 0 on success.
  */
 static int load_config(void)
 {

--- a/audisp/plugins/zos-remote/zos-remote-ldap.c
+++ b/audisp/plugins/zos-remote/zos-remote-ldap.c
@@ -69,7 +69,7 @@ static struct zos_remote_error zos_remote_errlist[] = {
         {ZOS_REMOTE_MAJOR_RACROUTE,     "RACROUTE - The R_auditx service returned an unexpected error"},
         {ZOS_REMOTE_MAJOR_VAL_ERR,      "VAL_ERR - Value error in request"},
         {ZOS_REMOTE_MAJOR_ENC_ERR,      "ENC_ERR - DER decoding error in request"},
-        {ZOS_REMOTE_MAJOR_UNSUF_AUTH,   "UNSUF_AUTH - The user has unsufficient authority for the requested function"},
+        {ZOS_REMOTE_MAJOR_UNSUF_AUTH,   "UNSUF_AUTH - The user has insufficient authority for the requested function"},
         {ZOS_REMOTE_MAJOR_EMPTY,        "EMPTY - Empty request received - No items found within the ItemList"},
         {ZOS_REMOTE_MAJOR_INVALID_VER,  "INVALID_VER - Invalid RequestVersion"},
         {ZOS_REMOTE_MAJOR_INTERNAL_ERR, "INTERNAL_ERR - An internal error was encountered within the ICTX component"},
@@ -437,7 +437,7 @@ int submit_xop_s(ZOS_REMOTE *zos_remote, struct berval *bv)
 
         if (response.respMajor == ZOS_REMOTE_MAJOR_SUCCESS) {
                 /* submission was successful, no further processing needed */
-                log_debug("Successfully submited Remote audit Request");
+                log_debug("Successfully submitted Remote audit Request");
                 rc = ICTX_SUCCESS;
                 goto free_response;
         } else if (response.respMajor == ZOS_REMOTE_MAJOR_EMPTY) {
@@ -484,7 +484,7 @@ int submit_xop_s(ZOS_REMOTE *zos_remote, struct berval *bv)
                         log_err("Error - LDAP extended operation returned '%s' for item %d",
                                 zos_remote_err2string((response.itemList[i])->majorCode),
                                 (response.itemList[i])->itemTag);
-                        log_err("Item field: %d, reson %d",
+                        log_err("Item field: %d, reason %d",
                                 (response.itemList[i])->
                                 minorCode1,
                                 (response.itemList[i])->minorCode2);

--- a/audisp/plugins/zos-remote/zos-remote-plugin.c
+++ b/audisp/plugins/zos-remote/zos-remote-plugin.c
@@ -302,7 +302,7 @@ push_event(auparse_state_t * au, auparse_cb_event_t cb_event_type,
                 rc |= ber_printf(ber, "s", type);
                 
                 /* 
-                 * Nineth field is the LogString
+                 * Ninth field is the LogString
                  * we try to put something meaningful here
                  * we also start the relocations sequence
                  */
@@ -333,7 +333,7 @@ push_event(auparse_state_t * au, auparse_cb_event_t cb_event_type,
                         /* 
                          * we set a maximum of 1024 chars for
                          * relocation data (field=value pairs)
-                         * Hopefuly this wont overflow too often
+                         * Hopefully this wont overflow too often
                          */
                         char data[1024];
                         const char *name = auparse_get_field_name(au);

--- a/auparse/data_buf.c
+++ b/auparse/data_buf.c
@@ -228,7 +228,7 @@ int databuf_append(DataBuf *db, const char *src, size_t src_size)
 #ifdef DEBUG
     if (debug) databuf_print(db, 1, "databuf_append() about to memmove()");
 #endif
-    /* pointers all set up and room availble, move the data and update */
+    /* pointers all set up and room available, move the data and update */
     memmove(databuf_end(db), src, src_size);
     db->len = new_size;
     db->max_len = MAX(db->max_len, new_size);

--- a/auparse/ellist.c
+++ b/auparse/ellist.c
@@ -98,7 +98,7 @@ static char *escape(const char *tmp)
 	return name;
 }
 
-/* This funtion does the heavy duty work of splitting a record into
+/* This function does the heavy duty work of splitting a record into
  * its little tiny pieces */
 static int parse_up_record(rnode* r)
 {
@@ -113,7 +113,7 @@ static int parse_up_record(rnode* r)
 	}
 	r->interp = ptr;
 	// Rather than call strndup, we will do it ourselves to reduce
-	// the number of interations across the record.
+	// the number of interactions across the record.
 	// len includes the string terminator.
 	len = strlen(r->record) + 1;
 	r->nv.record = buf = malloc(len);

--- a/auparse/expression.c
+++ b/auparse/expression.c
@@ -939,8 +939,8 @@ err:
 	return NULL;
 }
 
-/* Create a binary expresion for OP and subexpressions E1 and E2.
-   On success, return the created expresion.
+/* Create a binary expression for OP and subexpressions E1 and E2.
+   On success, return the created expression.
    On error, set errno and return NULL. */
 struct expr *
 expr_create_binary(unsigned op, struct expr *e1, struct expr *e2)

--- a/auparse/expression.h
+++ b/auparse/expression.h
@@ -123,8 +123,8 @@ struct expr *expr_create_field_exists(const char *field);
    On error, set errno and return NULL. */
 struct expr *expr_create_regexp_expression(const char *regexp);
 
-/* Create a binary expresion for OP and subexpressions E1 and E2.
-   On success, return the created expresion.
+/* Create a binary expression for OP and subexpressions E1 and E2.
+   On success, return the created expression.
    On error, set errno and return NULL. */
 struct expr *expr_create_binary(unsigned op, struct expr *e1, struct expr *e2);
 

--- a/auparse/internal.h
+++ b/auparse/internal.h
@@ -65,7 +65,7 @@ typedef enum { EVENT_EMPTY, EVENT_ACCUMULATING, EVENT_EMITTED } auparser_state_t
  * EBS_EMPTY: node is scheduled for emptying (freeing)
  * EBS_BUILDING: node is still building (awaiting more records and/or awaiting
  *               an End of Event action)
- * EBS_COMPLETE: node is complete and avaiable for use
+ * EBS_COMPLETE: node is complete and available for use
  *
  * The old auparse() library processed events as they appeared and hence failed
  * to deal with interleaved records. The old library kept a 'current' event
@@ -93,7 +93,7 @@ typedef struct {
 } au_lol;
 
 /*
- * The list is a dynamically growable list. We initally hold ARRAY_LIMIT
+ * The list is a dynamically growable list. We initially hold ARRAY_LIMIT
  * events and grow by ARRAY_LIMIT if we need to maintain more events at
  * any one time
  */

--- a/auparse/interpret.c
+++ b/auparse/interpret.c
@@ -2416,7 +2416,7 @@ static const char *print_trust(const char *val)
 	return out;
 }
 
-// fan_type always preceeds fan_info
+// fan_type always precedes fan_info
 static int last_type = 2;
 static const char *print_fan_type(const char *val)
 {

--- a/auparse/test/auparselol_test.c
+++ b/auparse/test/auparselol_test.c
@@ -20,7 +20,7 @@
  *	sed -f auparse_patch.sed /tmp/auparse_test/audit.log | sort > /tmp/auparse_test/auparse.raw
  *	auparselol_test --check -f /tmp/auparse_test/audit.log | sort > /tmp/auparse_test/auparse.new
  *	diff /tmp/auparse_test/auparse.raw /tmp/auparse_test/auparse.new
- * and the ouput of the diff should be zero or explainable (and hence expand the auparse_patch.sed file)
+ * and the output of the diff should be zero or explainable (and hence expand the auparse_patch.sed file)
  *
  */
 

--- a/docs/audispd-zos-remote.8
+++ b/docs/audispd-zos-remote.8
@@ -222,7 +222,7 @@ No profile found for specified resource. There is no @LINUX Class configured or 
 The user ID associated with the ITDS doesn't have READ access to the IRR.AUDITX FACILITY Class profile. See
 .B IBM z/OS RACF Server configuration
 .TP
-.B UNSUF_AUTH - The user has unsufficient authority for the requested function
+.B UNSUF_AUTH - The user has insufficient authority for the requested function
 The RACF user ID used to perform Remote Audit requests (as configured in
 .BR zos-remote.conf (5))
 don't have access to the IRR.LDAP.REMOTE.AUDIT FACILITY Class profile. See

--- a/docs/auparse_find_field.3
+++ b/docs/auparse_find_field.3
@@ -10,7 +10,7 @@ const char *auparse_find_field(auparse_state_t *au, const char *name);
 
 auparse_find_field will scan all records in an event to find the first occurrence of the field name passed to it. Searching begins from the cursor's current position. The field name is stored for subsequent searching.
 
-NOTE: auparse creates 2 psuedo fields that do not exist in the natural record for SELinux AVC and USER_AVC decision and permissions. The field names are seresult and seperms respectively.
+NOTE: auparse creates 2 pseudo fields that do not exist in the natural record for SELinux AVC and USER_AVC decision and permissions. The field names are seresult and seperms respectively.
 
 .SH "RETURN VALUE"
 

--- a/init.d/auditd.service
+++ b/init.d/auditd.service
@@ -4,7 +4,7 @@ ConditionKernelCommandLine=!audit=0
 ConditionKernelCommandLine=!audit=off
 DefaultDependencies=no
 Requires=audit-rules.service
-## If auditd is sending or recieving remote logging, copy this file to
+## If auditd is sending or receiving remote logging, copy this file to
 ## /etc/systemd/system/auditd.service and comment out the first After and
 ## uncomment the second so that network-online.target is part of After.
 ## then comment the first Before and uncomment the second Before to remove

--- a/init.d/augenrules
+++ b/init.d/augenrules
@@ -124,7 +124,7 @@ fi
 if [ -f ${DestinationFile} ]; then
 	cp ${DestinationFile} ${DestinationFile}.${ASuffix}
 fi
-# We copy the file so that it gets the right selinux lable
+# We copy the file so that it gets the right selinux label
 cp "${TmpRules}" ${DestinationFile}
 chmod 0640 ${DestinationFile}
 # Restore context on MLS system. /tmp is SystemLow & audit.rules is SystemHigh

--- a/lib/libaudit.c
+++ b/lib/libaudit.c
@@ -110,7 +110,7 @@ static const struct kw_pair keywords[] =
 static int audit_priority(int xerrno)
 {
 	/* If they've compiled their own kernel and did not include
-	 * the audit susbsystem, they will get ECONNREFUSED. We'll
+	 * the audit subsystem, they will get ECONNREFUSED. We'll
 	 * demote the message to debug so its not lost entirely. */
 	if (xerrno == ECONNREFUSED)
 		return LOG_DEBUG;
@@ -743,7 +743,7 @@ int audit_update_watch_perms(struct audit_rule_data *rule, int perms)
 
 	if (rule->field_count < 1) {
 		audit_msg(LOG_ERR,
-			 "Permissions should be preceeded by other fields");
+			 "Permissions should be preceded by other fields");
 		return -1;
 	}
 

--- a/src/auditctl.c
+++ b/src/auditctl.c
@@ -557,7 +557,7 @@ static int report_status(void)
 }
 
 #ifdef WITH_IO_URING
-// return 0 on success and -1 if unknow op.
+// return 0 on success and -1 if unknown op.
 static int parse_io_uring(const char *optarg)
 {
 	if (strchr(optarg, ',')) {

--- a/src/auditd-event.c
+++ b/src/auditd-event.c
@@ -225,7 +225,7 @@ static void *flush_thread_main(void *arg)
 }
 
 /* We setup the flush thread no matter what. This is incase a reconfig
- * changes from non incremental to incremental or vise versa. */
+ * changes from non incremental to incremental or vice versa. */
 static void init_flush_thread(void)
 {
 	pthread_mutex_init(&flush_lock, NULL);

--- a/src/auditd-listen.c
+++ b/src/auditd-listen.c
@@ -329,7 +329,7 @@ static void gss_failure(const char *msg, int major_status, int minor_status)
 		return -1; }
 
 /* These are our private credentials, which come from a key file on
-   our server.  They are aquired once, at program start.  */
+   our server.  They are acquired once, at program start.  */
 static krb5_context kcontext = NULL;
 static int server_acquire_creds(const char *service_name,
 		gss_cred_id_t *lserver_creds)

--- a/src/ausearch-parse.c
+++ b/src/ausearch-parse.c
@@ -2435,7 +2435,7 @@ static int parse_simple_message(const lnode *n, search_items *s)
 
 	// defaulting this to 1 for these messages. The kernel generally
 	// does not log the res since it can be nothing but success. 
-	// But it can still be overriden below if res= is found in the event
+	// But it can still be overridden below if res= is found in the event
 	if (n->type == AUDIT_CONFIG_CHANGE) 
 		s->success = S_SUCCESS;
 

--- a/src/ausearch.c
+++ b/src/ausearch.c
@@ -62,7 +62,7 @@ static int get_next_event(llist **);
 
 extern const char *checkpt_filename;	/* checkpoint file name */
 extern int checkpt_timeonly;	/* use timestamp from within checkpoint file */
-static int have_chkpt_data = 0;		/* have checkpt need to compare wit */
+static int have_chkpt_data = 0;		/* have checkpt need to compare with */
 extern char *user_file;
 extern int force_logs;
 static int userfile_is_dir = 0;
@@ -192,7 +192,7 @@ int main(int argc, char *argv[])
 
 	/* Generate a checkpoint if required */
 	if (checkpt_filename) {
-		/* Providing haven't failed and have sucessfully read data
+		/* Providing haven't failed and have successfully read data
 		 *  records, save a checkpoint */
 		if (!checkpt_failure && (rc == 0))
 			save_ChkPt(checkpt_filename);

--- a/tools/ausyscall/ausyscall.8
+++ b/tools/ausyscall/ausyscall.8
@@ -8,7 +8,7 @@ ausyscall \- a program that allows mapping syscall names and numbers
 
 The program takes the special arch,
 .B uring,
-to denote that you want to specify io_uring operations. In this case, the arch must be given because it will otherwise detect the underlying harware.
+to denote that you want to specify io_uring operations. In this case, the arch must be given because it will otherwise detect the underlying hardware.
 
 This program can be used to verify syscall numbers on a biarch platform for rule optimization. For example, suppose you had an auditctl rule:
 


### PR DESCRIPTION
Found by codespell(1) and typos[1] (embedded libev source excluded).

[1]: https://github.com/crate-ci/typos