### PR TITLE
lib: rework format strings

### DIFF
--- a/lib/audit_logging.c
+++ b/lib/audit_logging.c
@@ -479,7 +479,7 @@ int audit_log_acct_message(int audit_fd, int type, const char *pgname,
 
 	if (name && id == -1) {
 		char user[MAX_USER];
-		const char *format;
+		int encoded = 0;
 		size_t len;
 
 		user[0] = 0;
@@ -488,13 +488,12 @@ int audit_log_acct_message(int audit_fd, int type, const char *pgname,
 		user[len] = 0;
 		if (audit_value_needs_encoding(name, len)) {
 			audit_encode_value(user, name, len);
-			format = 
-	     "op=%s acct=%s exe=%s hostname=%s addr=%s terminal=%s res=%s";
-		} else
-			format = 
-	 "op=%s acct=\"%s\" exe=%s hostname=%s addr=%s terminal=%s res=%s";
+			encoded = 1;
+		}
 
-		snprintf(buf, sizeof(buf), format,
+		snprintf(buf, sizeof(buf),
+			encoded ? "op=%s acct=%s exe=%s hostname=%s addr=%s terminal=%s res=%s"
+			        : "op=%s acct=\"%s\" exe=%s hostname=%s addr=%s terminal=%s res=%s",
 			op, user, exename,
 			host ? host : "?",
 			addrbuf,
@@ -653,7 +652,7 @@ int audit_log_semanage_message(int audit_fd, int type, const char *pgname,
 
 	if (name && strlen(name) > 0) {
 		size_t len;
-		const char *format;
+		int encoded = 0;
 		char user[MAX_USER];
 
 		user[0] = 0;
@@ -662,10 +661,13 @@ int audit_log_semanage_message(int audit_fd, int type, const char *pgname,
 		user[len] = 0;
 		if (audit_value_needs_encoding(name, len)) {
 			audit_encode_value(user, name, len);
-			format = "op=%s acct=%s old-seuser=%s old-role=%s old-range=%s new-seuser=%s new-role=%s new-range=%s exe=%s hostname=%s addr=%s terminal=%s res=%s";
-		} else
-			format = "op=%s acct=\"%s\" old-seuser=%s old-role=%s old-range=%s new-seuser=%s new-role=%s new-range=%s exe=%s hostname=%s addr=%s terminal=%s res=%s";
-		snprintf(buf, sizeof(buf), format, op, user, 
+			encoded = 1;
+		}
+
+		snprintf(buf, sizeof(buf),
+			encoded ?  "op=%s acct=%s old-seuser=%s old-role=%s old-range=%s new-seuser=%s new-role=%s new-range=%s exe=%s hostname=%s addr=%s terminal=%s res=%s"
+			        : "op=%s acct=\"%s\" old-seuser=%s old-role=%s old-range=%s new-seuser=%s new-role=%s new-range=%s exe=%s hostname=%s addr=%s terminal=%s res=%s",
+			op, user,
 			old_seuser && strlen(old_seuser) ? old_seuser : "?",
 			old_role && strlen(old_role) ? old_role : "?",
 			old_range && strlen(old_range) ? old_range : "?",

--- a/lib/libaudit.c
+++ b/lib/libaudit.c
@@ -1522,7 +1522,7 @@ static int audit_add_perm_syscalls(int perm, struct audit_rule_data *rule)
 		_audit_syscalladded = 1;
 		break;
 	case -1: // Should never happen
-		audit_msg(LOG_ERR, "Syscall name unknown: %s", syscall);
+		audit_msg(LOG_ERR, "Syscall name unknown: %s", syscalls);
 		break;
 	default: // Error reported - do nothing here
 		break;


### PR DESCRIPTION
Allow the compiler to verify the format string matches the supplied arguments.