### PR TITLE
lib: declare read-only parameters of audit_format_signal_info() const

### DIFF
--- a/lib/libaudit.c
+++ b/lib/libaudit.c
@@ -696,14 +696,14 @@ int audit_request_signal_info(int fd)
 	return rc;
 }
 
-char *audit_format_signal_info(char *buf, int len, char *op,
-			       struct audit_reply *rep, char *res)
+char *audit_format_signal_info(char *buf, int len, const char *op,
+			       const struct audit_reply *rep, const char *res)
 {
 	struct stat sb;
 	char path[32], ses[16];
 	int rlen;
 	snprintf(path, sizeof(path), "/proc/%u", rep->signal_info->pid);
-	int fd = open(path, O_RDONLY);
+	int fd = open(path, O_RDONLY|O_DIRECTORY);
 	if (fd >= 0) {
 		if (fstat(fd, &sb) < 0)
 			sb.st_uid = -1;

--- a/lib/libaudit.h
+++ b/lib/libaudit.h
@@ -196,8 +196,8 @@ int  audit_setloginuid(uid_t uid);
 uint32_t audit_get_session(void);
 int  audit_detect_machine(void);
 int audit_determine_machine(const char *arch);
-char *audit_format_signal_info(char *buf, int len, char *op,
-			struct audit_reply *rep, char *res)
+char *audit_format_signal_info(char *buf, int len, const char *op,
+			const struct audit_reply *rep, const char *res)
 			__attr_access ((__write_only__, 1, 2));
 
 /* Translation functions */


### PR DESCRIPTION
Also /proc/<pid> should be a directory.