### PR TITLE
ausearch: add option to exclude by message type

### DIFF
--- a/docs/ausearch.8
+++ b/docs/ausearch.8
@@ -112,6 +112,9 @@ Flush output on every line. Most useful when stdout is connected to a pipe and t
 .BR \-m ,\  \-\-message \ \fImessage-type\fP\ |\ \fIcomma-sep-message-type-list\fP
 Search for an event matching the given \fImessage type\fP. (Message types are also known as record types.) You may also enter a \fIcomma separated list of message types\fP or multiple individual message types each with its own \fI-m\fP option. There is an \fBALL\fP message type that doesn't exist in the actual logs. It allows you to get all messages in the system. The list of valid messages types is long. The program will display the list whenever no message type is passed with this parameter. The message type can be either text or numeric. If you enter a list, there can be only commas and no spaces separating the list.
 .TP
+.BR \-M ,\  \-\-message-exclude \ \fImessage-type\fP\ |\ \fIcomma-sep-message-type-list\fP
+Filter out events matching the given \fImessage type\fP. (Message types are also known as record types.) You may also enter a \fIcomma separated list of message types\fP or multiple individual message types each with its own \fI-m\fP option. There is an \fBALL\fP message type that doesn't exist in the actual logs. It allows you to exclude all messages in the system. The list of valid messages types is long. The program will display the list whenever no message type is passed with this parameter. The message type can be either text or numeric. If you enter a list, there can be only commas and no spaces separating the list. This option is mutual exclusive with the option \fB\-m\fP.
+.TP
 .BR \-n ,\  \-\-node
 Search for events originating from a specific machine. Multiple nodes are allowed, and if any nodes match, the event is matched. This search uses the node field in audit events. Also see the \-\-host command which search for events related to host information in the audit trail.
 .TP

--- a/src/ausearch-match.c
+++ b/src/ausearch-match.c
@@ -144,7 +144,7 @@ int match(llist *l)
 						if (found)
 							break;
 					} while ((n = list_next(l)));
-					if (!found)
+					if (!(found ^ event_type_inverted))
 						return 0;
 				}
 

--- a/src/ausearch-options.h
+++ b/src/ausearch-options.h
@@ -41,6 +41,7 @@ extern int event_debug;
 extern pid_t event_ppid;
 extern uint32_t event_session_id;
 extern ilist *event_type;
+extern int event_type_inverted;
 
 /* Data type to govern output format */
 extern report_t report_format;


### PR DESCRIPTION
Similar to the existing option `-m`, which searches by the given message type(s), add the option `-M` to exclude by the given message type(s).