### PR TITLE
audispd: Variable amount of arguments

### DIFF
--- a/audisp/audispd-pconfig.h
+++ b/audisp/audispd-pconfig.h
@@ -26,7 +26,6 @@
 
 #include <sys/types.h>
 #include "libaudit.h"
-#define MAX_PLUGIN_ARGS 3
 
 typedef enum { A_NO, A_YES } active_t;
 typedef enum { D_UNSET, D_IN, D_OUT } direction_t;
@@ -39,7 +38,8 @@ typedef struct plugin_conf
 	direction_t direction;	/* in or out kind of plugin */
 	const char *path;	/* path to binary */
 	service_t type;		/* builtin or always */
-	char *args[MAX_PLUGIN_ARGS+2];	/* args to be passed to plugin */
+	char **args;	/* args to be passed to plugin */
+	int nargs;
 	format_t format;	/* Event format */
 	int plug_pipe[2];	/* Communication pipe for events */
 	pid_t pid;		/* Used to signal children */

--- a/audisp/audispd.c
+++ b/audisp/audispd.c
@@ -401,11 +401,6 @@ static int safe_exec(plugin_conf_t *conf)
 	char **argv;
 	int pid, i;
 
-	argv = calloc(conf->nargs + 2, sizeof(char *));
-	if (argv == NULL) {
-		return -1;
-	}
-
 	/* Set up IPC with child */
 	if (socketpair(AF_UNIX, SOCK_STREAM, 0, conf->plug_pipe) != 0)
 		return -1;
@@ -413,7 +408,6 @@ static int safe_exec(plugin_conf_t *conf)
 	pid = fork();
 	if (pid > 0) {
 		conf->pid = pid;
-		free(argv);
 		return 0;	/* Parent...normal exit */
 	}
 	if (pid < 0) {
@@ -432,6 +426,11 @@ static int safe_exec(plugin_conf_t *conf)
 	}
 	for (i=3; i<24; i++)	 /* Arbitrary number */
 		close(i);
+
+	argv = calloc(conf->nargs + 2, sizeof(char *));
+	if (argv == NULL) {
+		return -1;
+	}
 
 	/* Child */
 	argv[0] = (char *)conf->path;


### PR DESCRIPTION
Every plugin configuration line comprises a key = value pair, optionally followed by an additional option at the line's end. Previously, if the value consisted of multiple words, an error would occur. This commit addresses the issue, allowing for the specification of multiple space-separated arguments in a plugin configuration. For instance, the audisp-syslog plugin can handle 3 arguments, but we were not able to pass all 3 at a single time due to this limitation.

```
args = LOG_NOTICE LOG_LOCAL0 interpret
```