### PR TITLE
audisp-filter: new plugin that provides audit event filtering capability

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -32,6 +32,7 @@ cscope.*
 audisp/audispd
 audisp/plugins/af_unix/audisp-af_unix
 audisp/plugins/remote/audisp-remote
+audisp/plugins/filter/audisp-filter
 audisp/plugins/syslog/audisp-syslog
 audisp/plugins/zos-remote/audispd-zos-remote
 audisp/plugins/statsd/audisp-statsd

--- a/audisp/plugins/Makefile.am
+++ b/audisp/plugins/Makefile.am
@@ -23,7 +23,7 @@
 
 CONFIG_CLEAN_FILES = *.loT *.rej *.orig
 
-SUBDIRS = af_unix remote syslog
+SUBDIRS = af_unix remote syslog filter
 if ENABLE_EXPERIMENTAL
 SUBDIRS += ids statsd
 endif

--- a/audisp/plugins/filter/Makefile.am
+++ b/audisp/plugins/filter/Makefile.am
@@ -22,11 +22,12 @@
 #
 
 CONFIG_CLEAN_FILES = *.loT *.rej *.orig
-EXTRA_DIST = filter-syslog.conf $(man_MANS)
+EXTRA_DIST = filter.conf audisp-filter.conf $(man_MANS)
 AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/lib -I${top_srcdir}/common -I${top_srcdir}/auparse
 prog_confdir = $(sysconfdir)/audit
+prog_conf = audisp-filter.conf
 plugin_confdir=$(prog_confdir)/plugins.d
-plugin_conf = filter-syslog.conf
+plugin_conf = filter.conf
 sbin_PROGRAMS = audisp-filter
 man_MANS = audisp-filter.8
 
@@ -39,7 +40,9 @@ audisp_filter_LDADD = $(CAPNG_LDADD) ${top_builddir}/common/libaucommon.la ${top
 install-data-hook:
 	mkdir -p -m 0750 ${DESTDIR}${plugin_confdir}
 	$(INSTALL_DATA) -D -m 640 ${srcdir}/$(plugin_conf) ${DESTDIR}${plugin_confdir}
+	$(INSTALL_DATA) -D -m 640 ${srcdir}/$(prog_conf) ${DESTDIR}${prog_confdir}
 
 uninstall-hook:
 	rm ${DESTDIR}${plugin_confdir}/$(plugin_conf)
+	rm ${DESTDIR}${prog_confdir}/$(prog_conf)
 

--- a/audisp/plugins/filter/Makefile.am
+++ b/audisp/plugins/filter/Makefile.am
@@ -1,0 +1,45 @@
+# Makefile.am --
+# Copyright 2024 Red Hat Inc., Durham, North Carolina.
+# All Rights Reserved.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+#
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program; see the file COPYING. If not, write to the
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
+# Boston, MA 02110-1335, USA.
+#
+# Authors:
+#   Attila Lakatos <alakatos@redhat.com>
+#
+
+CONFIG_CLEAN_FILES = *.loT *.rej *.orig
+EXTRA_DIST = filter-syslog.conf $(man_MANS)
+AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/lib -I${top_srcdir}/common -I${top_srcdir}/auparse
+prog_confdir = $(sysconfdir)/audit
+plugin_confdir=$(prog_confdir)/plugins.d
+plugin_conf = filter-syslog.conf
+sbin_PROGRAMS = audisp-filter
+man_MANS = audisp-filter.8
+
+audisp_filter_DEPENDENCIES = ${top_builddir}/common/libaucommon.la
+audisp_filter_SOURCES = audisp-filter.c
+audisp_filter_CFLAGS = -fPIE -DPIE -g -D_GNU_SOURCE -Wundef ${WFLAGS}
+audisp_filter_LDFLAGS = -pie -Wl,-z,relro -Wl,-z,now
+audisp_filter_LDADD = $(CAPNG_LDADD) ${top_builddir}/common/libaucommon.la ${top_builddir}/auparse/libauparse.la
+
+install-data-hook:
+	mkdir -p -m 0750 ${DESTDIR}${plugin_confdir}
+	$(INSTALL_DATA) -D -m 640 ${srcdir}/$(plugin_conf) ${DESTDIR}${plugin_confdir}
+
+uninstall-hook:
+	rm ${DESTDIR}${plugin_confdir}/$(plugin_conf)
+

--- a/audisp/plugins/filter/audisp-filter.8
+++ b/audisp/plugins/filter/audisp-filter.8
@@ -1,0 +1,52 @@
+.TH AUDISP-SYSLOG "8" "February 2024" "Red Hat" "System Administration Utilities"
+.SH NAME
+audisp-filter \- plugin to filter audit events and forward them to other plugins
+.SH SYNOPSIS
+.B audisp-filter
+\fIMODE CONFIG_FILE BINARY\fP [ \fIBINARY_ARGS\fP ]
+.SH DESCRIPTION
+\fBaudisp-filter\fP is an audit event dispatcher plugin designed to filter out specific events based on its provided configuration. Moreover, it possesses the capability to forward the remaining logs to other plugins. The plugin is universally compatible, allowing seamless integration with any existing audit plugin that expects audit messages on its standard input. Currently it supports the following arguments:
+.RS
+.TP
+.B MODE
+The operational mode can be either allowlist or blocklist. In allowlist mode, the plugin forwards everything except for events that match the specified ausearch expressions in the configuration. Conversely, in blocklist mode, it refrains from forwarding anything except for events listed in the configuration.
+.TP
+.B CONFIG_FILE
+Path to the main configuration file containing ausearch expressions.
+.TP
+.B BINARY
+Path to an external program that will consistently receive filtered audit events through its standard input.
+.TP
+.B BINARY_ARGS
+Optionally, you can pass additional arguments to the external program.
+.RE
+
+.SH CONFIGURATION AND RULES EVALUATION
+Every single plugin that wants to benefit from the event filtering capability needs to create its own configuration file. It's a good practice to place this file inside the audit config directory, following the naming convention audisp-filter-pluginname.conf, for instance,
+.B audisp-filter-syslog.conf
+to filter audit events before sending them to syslog.
+
+Each line within a configuration represents an ausearch-expression (5). Internally, these expressions are joined using the OR operator. Therefore, every expression is substituted with (PE || CE), where PE represents the previous expression and CE denotes the current expression being processed.
+Lines starting with a
+.B '#'
+character are treated as comments and do not influence the final rule set.
+
+Upon the creation of an audit event, the filtering engine goes through the list of expressions, constructing the final expression representing our rule set. The event in question will be searched using this expression. The decision to forward an audit event to the configured binary depends on two factors: the operational mode of audisp-filter and whether the expression matches the ongoing event.
+
+.SH EXAMPLE
+Example1: Do not syslog audit events containing unsuccessful openat syscalls.
+
+First, in the plugin config, make sure that operation mode is set to allowlist, the binary points to /sbin/audispFyslog and provide any additional arguments if needed. Next, create the plugin specific config file with the content below. Before enabling the audit plugin, always make sure the syntax is correct. This can be checked by calling audisp-filter --check path/to/config/file.
+
+.B (type r= SYSCALL && syscall r= openat && success r= yes)
+
+
+.SH FILES
+/etc/audit/plugins/filter.conf
+/etc/audit/auditd.conf
+.SH "SEE ALSO"
+.BR auditd.conf (8),
+.BR ausearch-expression (5),
+.BR auditd-plugins (5).
+.SH AUTHOR
+Attila Lakatos

--- a/audisp/plugins/filter/audisp-filter.c
+++ b/audisp/plugins/filter/audisp-filter.c
@@ -1,0 +1,532 @@
+/* audisp-filter.c --
+ * Copyright 2024 Red Hat Inc.
+ * All Rights Reserved.
+ *
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2 of the License, or
+ * (at your option) any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Authors:
+ *   Attila Lakatos <alakatos@redhat.com>
+ *
+ */
+
+#include <errno.h>
+#include <fcntl.h>
+#include <signal.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <sys/select.h>
+#include <sys/stat.h>
+#include <sys/wait.h>
+#include <syslog.h>
+
+#include "config.h"
+#ifdef HAVE_LIBCAP_NG
+#include <cap-ng.h>
+#endif
+#include "auparse.h"
+#include "common.h"
+#include "libaudit.h"
+
+struct filter_rule {
+	char* expr;
+	int lineno;
+	struct filter_rule* next;
+};
+
+struct filter_list {
+	struct filter_rule* head;
+	struct filter_rule* tail;
+};
+
+enum {
+	ALLOWLIST,
+	BLOCKLIST
+};
+
+struct filter_conf {
+	int mode; /* allowlist or blocklist */
+	const char* binary; /* external program that will receive filter audit events */
+	char** binary_args; /* arguments for external program */
+	const char* config_file; /* file containing audit expressions */
+	int only_check; /* just verify the syntax of the config_file and exit */
+};
+
+/* Global Data */
+static volatile int stop = 0;
+static volatile int hup = 0;
+static int pipefd[2];
+static int errors = 0;
+static struct filter_list list;
+pid_t cpid = -1;
+
+static struct filter_conf config = {
+	.mode = -1,
+	.binary = NULL,
+	.binary_args = NULL,
+	.config_file = NULL,
+	.only_check = 0
+};
+
+static void handle_event(auparse_state_t* au, auparse_cb_event_t cb_event_type,
+	void* user_data) {
+	if (cb_event_type != AUPARSE_CB_EVENT_READY)
+		return;
+
+	int rc, forward_event;
+
+	ausearch_set_stop(au, AUSEARCH_STOP_EVENT);
+
+	// add rules(expressions) to the ausearch engine
+	for (struct filter_rule* rule = list.head; rule != NULL; rule = rule->next) {
+		char* error = NULL;
+		rc = ausearch_add_expression(au, rule->expr, &error, AUSEARCH_RULE_OR);
+		if (rc != 0) {
+			syslog(LOG_ERR, "Failed to add expression '%s' to ausearch (%s)",
+				rule->expr, error);
+			free(error);
+			goto cleanup;
+		}
+		free(error);
+	}
+
+	// Determine whether to forward or drop the event
+	rc = ausearch_cur_event(au);
+	if (rc > 0) { /* matched */
+		forward_event = (config.mode == ALLOWLIST) ? 0 : 1;
+	} else if (rc == 0) { /* not matched */
+		forward_event = (config.mode == ALLOWLIST) ? 1 : 0;
+	} else {
+		syslog(LOG_ERR, "The ausearch_next_event returned %d", rc);
+		goto cleanup;
+	}
+
+	if (forward_event) {
+		const int records = auparse_get_num_records(au);
+		for (int i = 0; i < records; i++) {
+			const char* txt = auparse_get_record_text(au);
+
+			// Need to add new line character to signal end of the current record
+			if (write(pipefd[1], txt, strlen(txt)) == -1 || write(pipefd[1], "\n", 1) == -1) {
+				syslog(LOG_ERR, "Failed to write to pipe");
+				goto cleanup;
+			}
+		}
+	}
+
+cleanup:
+	ausearch_clear(au);
+}
+
+static void free_args() {
+	if (config.binary_args) {
+		for (int i = 0; config.binary_args[i] != NULL; i++) {
+			free(config.binary_args[i]);
+		}
+		free(config.binary_args);
+	}
+}
+
+static int parse_args(int argc, const char* argv[]) {
+	if (argc == 3 && (strcmp("--check", argv[1]) == 0)) {
+		config.config_file = argv[2];
+		config.only_check = 1;
+		return 0;
+	}
+
+	if (argc <= 3) {
+		syslog(LOG_ERR, "Not enough command line arguments", argv[0]);
+		return 1;
+	}
+
+	if (strcasecmp(argv[1], "allowlist") == 0)
+		config.mode = ALLOWLIST;
+	else if (strcasecmp(argv[1], "blocklist") == 0)
+		config.mode = BLOCKLIST;
+	else {
+		syslog(LOG_ERR,
+			"Invalid mode '%s' specified, possible values are: allowlist, "
+			"blocklist.",
+			argv[1]);
+		return 1;
+	}
+
+	config.config_file = argv[2];
+	config.binary = argv[3];
+
+	argc -= 3;
+	argv += 3;
+
+	config.binary_args = malloc(sizeof(char*) * (argc + 1)); /* +1 is for the last NULL */
+	if (!config.binary_args)
+		return 1;
+
+	for (int i = 0; i < argc; i++) {
+		config.binary_args[i] = strdup(argv[i]);
+		if (!config.binary_args[i]) {
+			while (i > 0) {
+				free(config.binary_args[--i]);
+			}
+			free(config.binary_args);
+			return 1;
+		}
+	}
+	config.binary_args[argc] = NULL;
+
+	return 0;
+}
+
+static char* get_line(FILE* f, char* buf, unsigned size, int* lineno,
+	const char* file) {
+	int too_long = 0;
+
+	while (fgets_unlocked(buf, size, f)) {
+		/* remove newline */
+		char* ptr = strchr(buf, 0x0a);
+		if (ptr) {
+			if (!too_long) {
+				*ptr = 0;
+				return buf;
+			}
+			// Reset and start with the next line
+			too_long = 0;
+			*lineno = *lineno + 1;
+		} else {
+			// If a line is too long skip it.
+			// Only output 1 warning
+			if (!too_long)
+				syslog(LOG_WARNING, "Skipping line %d in %s: too long", *lineno, file);
+			too_long = 1;
+		}
+	}
+	return NULL;
+}
+
+static void print_rules(struct filter_list* list) {
+	struct filter_rule* rule;
+	int count = 0;
+
+	for (rule = list->head; rule != NULL; rule = rule->next, count++) {
+		printf("Rule %d on line %d: %s\n", count, rule->lineno, rule->expr);
+	}
+}
+
+static void reset_rules(struct filter_list* list) {
+	list->head = list->tail = NULL;
+}
+
+static void free_rule(struct filter_rule* rule) { free(rule->expr); }
+
+static void free_rules(struct filter_list* list) {
+	struct filter_rule* current = list->head, * to_delete;
+	while (current != NULL) {
+		to_delete = current;
+		current = current->next;
+		free_rule(to_delete);
+		free(to_delete);
+	}
+}
+
+static void append_rule(struct filter_list* list, struct filter_rule* rule) {
+	if (list->head == NULL) {
+		list->head = list->tail = rule;
+	} else {
+		list->tail->next = rule;
+		list->tail = rule;
+	}
+}
+
+static struct filter_rule* parse_line(char* line, int lineno) {
+	struct filter_rule* rule;
+	auparse_state_t* au;
+	const char* buf[] = { NULL };
+	int rc;
+	char* error = NULL;
+
+	/* dummy instance of the audit parsing library, we use it to
+	validate search expressions that will be added to the filter engine */
+	if ((au = auparse_init(AUSOURCE_BUFFER_ARRAY, buf)) == NULL) {
+		syslog(LOG_ERR, "The auparse_init failed");
+		return NULL;
+	}
+
+	// Skip whitespace
+	while (*line == ' ')
+		line++;
+
+	// Empty line or it's a comment
+	if (!*line || *line == '#') {
+		auparse_destroy(au);
+		return NULL;
+	}
+
+	if ((rule = malloc(sizeof(struct filter_rule))) == NULL) {
+		auparse_destroy(au);
+		return NULL;
+	}
+	rule->lineno = lineno;
+	rule->next = NULL;
+
+	if ((rule->expr = strdup(line)) == NULL) {
+		auparse_destroy(au);
+		free(rule);
+		return NULL;
+	}
+
+	if (ausearch_add_expression(au, rule->expr, &error, AUSEARCH_RULE_OR) != 0) {
+		syslog(LOG_ERR, "Invalid expression: %s (%s)", rule->expr, error);
+		free_rule(rule);
+		free(rule);
+		rule = NULL;
+		errors++;
+	}
+
+	auparse_destroy(au);
+	return rule;
+}
+
+/*
+ * Load rules from config into our linked list
+ */
+static int load_rules(struct filter_list* list) {
+	int fd, lineno = 0;
+	struct stat st;
+	char buf[1024];
+	FILE* f;
+
+	reset_rules(list);
+	errors = 0;
+
+	/* open the file */
+	if ((fd = open(config.config_file, O_RDONLY)) < 0) {
+		if (errno != ENOENT) {
+			syslog(LOG_ERR, "Error opening config file (%s)", strerror(errno));
+			return 1;
+		}
+		syslog(LOG_ERR, "Config file %s doesn't exist, skipping",
+			config.config_file);
+		return 1;
+	}
+
+	if (fstat(fd, &st) < 0) {
+		syslog(LOG_ERR, "Error fstat'ing config file (%s)", strerror(errno));
+		close(fd);
+		return 1;
+	}
+	if (st.st_uid != 0) {
+		syslog(LOG_ERR, "Error - %s isn't owned by root", config.config_file);
+		close(fd);
+		return 1;
+	}
+	if ((st.st_mode & S_IWOTH) == S_IWOTH) {
+		syslog(LOG_ERR, "Error - %s is world writable", config.config_file);
+		close(fd);
+		return 1;
+	}
+	if (!S_ISREG(st.st_mode)) {
+		syslog(LOG_ERR, "Error - %s is not a regular file", config.config_file);
+		close(fd);
+		return 1;
+	}
+
+	/* it's ok, read line by line */
+	f = fdopen(fd, "rm");
+	if (f == NULL) {
+		syslog(LOG_ERR, "Error - fdopen failed (%s)", strerror(errno));
+		close(fd);
+		return 1;
+	}
+
+	while (get_line(f, buf, sizeof(buf), &lineno, config.config_file)) {
+		lineno++;
+		struct filter_rule* rule;
+		if ((rule = parse_line(buf, lineno)) == NULL)
+			continue;
+
+		append_rule(list, rule);
+	}
+	fclose(f);
+
+	return errors;
+}
+
+/*
+ * SIGCHLD handler: reap exiting processes
+ */
+static void child_handler(int sig) {
+	while (waitpid(-1, NULL, WNOHANG) > 0)
+		printf("xD\n"); /* empty */
+	stop = 1;
+}
+
+/*
+ * SIGTERM handler
+ */
+static void term_handler(int sig) {
+	kill(cpid, sig);
+	stop = 1;
+}
+
+/*
+ * SIGHUP handler: re-read config
+ */
+static void hup_handler(int sig) {
+	kill(cpid, sig);
+	hup = 1;
+}
+
+static void reload_config(void) {
+	hup = 0;
+	struct filter_list new_list;
+
+	/* load new rules */
+	if (load_rules(&new_list)) {
+		syslog(LOG_INFO, "The rules were not reloaded because of a syntax error");
+		free_rules(&new_list);
+		return;
+	}
+
+	/* remove unused previous rules */
+	free_rules(&list);
+	list = new_list;
+	syslog(LOG_INFO, "Successfully reloaded rules");
+}
+
+int main(int argc, const char* argv[]) {
+	auparse_state_t* au = NULL;
+	struct sigaction sa;
+	char buffer[MAX_AUDIT_MESSAGE_LENGTH];
+
+	/* validate args */
+	if (parse_args(argc, argv))
+		return 1;
+
+	/* create a list of rules from config file */
+	if (load_rules(&list)) {
+		free_rules(&list);
+		free_args();
+		return 1;
+	}
+
+	/* validate the ruleset and exit */
+	if (config.only_check) {
+		free_rules(&list);
+		free_args();
+		return 0;
+	}
+
+	// print_rules(&list);
+
+	/* Register sighandlers */
+	sa.sa_flags = 0;
+	sigemptyset(&sa.sa_mask);
+	/* Set handler for the ones we care about */
+	sa.sa_handler = term_handler;
+	sigaction(SIGTERM, &sa, NULL);
+	sa.sa_handler = hup_handler;
+	sigaction(SIGHUP, &sa, NULL);
+	sa.sa_handler = child_handler;
+	sigaction(SIGCHLD, &sa, NULL);
+
+#ifdef HAVE_LIBCAP_NG
+	// Drop capabilities
+	capng_clear(CAPNG_SELECT_BOTH);
+	if (capng_apply(CAPNG_SELECT_BOTH))
+		syslog(LOG_WARNING,
+			"%s: unable to drop capabilities, continuing with "
+			"elevated privileges",
+			argv[0]);
+#endif
+
+	if (pipe(pipefd) == -1) {
+		syslog(LOG_ERR, "%s: unable to open a pipe (%s)",
+			argv[0], strerror(errno));
+		return -1;
+	}
+
+	cpid = fork();
+	if (cpid == -1) {
+		syslog(LOG_ERR, "%s: unable to create fork (%s)", argv[0], strerror(errno));
+		return -1;
+	}
+
+	if (cpid == 0) {
+		/* Child reads filtered input*/
+
+		close(pipefd[1]);
+		dup2(pipefd[0], STDIN_FILENO);
+		close(pipefd[0]);
+
+		execve(config.binary, config.binary_args, NULL);
+		syslog(LOG_ERR, "%s: execve failed (%s)", argv[0], strerror(errno));
+		exit(1);
+	} else {
+		/* Parent reads input and forwards data after filters have been applied
+		 */
+		close(pipefd[0]);
+
+		au = auparse_init(AUSOURCE_FEED, 0);
+		if (au == NULL) {
+			syslog(LOG_ERR, "%s: failed to initialize auparse data feed", argv[0]);
+			kill(cpid, SIGTERM);
+			return -1;
+		}
+
+		auparse_set_eoe_timeout(2);
+		auparse_add_callback(au, handle_event, NULL, NULL);
+		do {
+			fd_set read_mask;
+			int retval;
+			int read_size = 1; /* Set to 1 so it's not EOF */
+
+			/* Load configuration */
+			if (hup) {
+				reload_config();
+			}
+			do {
+				FD_ZERO(&read_mask);
+				FD_SET(0, &read_mask);
+
+				if (auparse_feed_has_data(au)) {
+					struct timeval tv;
+					tv.tv_sec = 1;
+					tv.tv_usec = 0;
+					retval = select(1, &read_mask, NULL, NULL, &tv);
+				} else
+					retval = select(1, &read_mask, NULL, NULL, NULL);
+
+				/* If we timed out & have events, shake them loose */
+				if (retval == 0 && auparse_feed_has_data(au))
+					auparse_feed_age_events(au);
+			} while (retval == -1 && errno == EINTR && !hup && !stop);
+
+			/* Now the event loop */
+			if (!stop && !hup && retval > 0) {
+				while ((read_size = read(0, buffer, MAX_AUDIT_MESSAGE_LENGTH)) > 0) {
+					auparse_feed(au, buffer, read_size);
+				}
+			}
+			if (read_size == 0) /* EOF */
+				break;
+		} while (stop == 0);
+
+		auparse_flush_feed(au);
+		auparse_destroy(au);
+	}
+
+	free_rules(&list);
+	free_args();
+	return 0;
+}

--- a/audisp/plugins/filter/audisp-filter.conf
+++ b/audisp/plugins/filter/audisp-filter.conf
@@ -1,0 +1,7 @@
+# Here you can specify a list of ausearch-expression(8)
+#
+# In allowlist mode, the plugin forwards everything except
+# for events that match the specified ausearch expressions.
+# In blocklist mode, it refrains from forwarding anything
+# except for events matching these expressions.
+# See audisp-filter

--- a/audisp/plugins/filter/filter-syslog.conf
+++ b/audisp/plugins/filter/filter-syslog.conf
@@ -1,0 +1,16 @@
+#
+# The audisp-filter plugin is designed to address
+# the need for event filtering in the Linux audit system.
+# It empowers users to selectively process audit events
+# based on specified criteria before they are e.g. forwarded
+# to syslog or sent to a remote destination for analysis.
+# The filter is generic and is designed to work in tandem
+# with other plugins which expect audit messages on their
+# standard input.
+
+active = no
+direction = out
+path = /sbin/audisp-filter
+type = always
+args = allowlist /etc/audit/filter-syslog.conf /sbin/audisp-syslog LOG_USER LOG_INFO interpret
+format = string

--- a/audisp/plugins/filter/filter.conf
+++ b/audisp/plugins/filter/filter.conf
@@ -7,10 +7,11 @@
 # The filter is generic and is designed to work in tandem
 # with other plugins which expect audit messages on their
 # standard input.
+# See audisp-filter(8)
 
 active = no
 direction = out
 path = /sbin/audisp-filter
 type = always
-args = allowlist /etc/audit/filter-syslog.conf /sbin/audisp-syslog LOG_USER LOG_INFO interpret
+args = allowlist /etc/audit/audisp-filter.conf /sbin/audisp-syslog LOG_USER LOG_INFO interpret
 format = string

--- a/configure.ac
+++ b/configure.ac
@@ -421,7 +421,7 @@ AC_SUBST(DEBUG)
 AC_SUBST(LIBWRAP_LIBS)
 #AC_SUBST(libev_LIBS)
 
-AC_CONFIG_FILES(Makefile common/Makefile lib/Makefile lib/audit.pc lib/test/Makefile auparse/Makefile auparse/test/Makefile auparse/auparse.pc src/Makefile src/libev/Makefile src/test/Makefile docs/Makefile rules/Makefile init.d/Makefile audisp/Makefile audisp/plugins/Makefile audisp/plugins/af_unix/Makefile audisp/plugins/remote/Makefile audisp/plugins/zos-remote/Makefile audisp/plugins/syslog/Makefile audisp/plugins/ids/Makefile audisp/plugins/ids/rules/Makefile audisp/plugins/statsd/Makefile bindings/Makefile bindings/python/Makefile bindings/python/python3/Makefile bindings/golang/Makefile bindings/swig/Makefile bindings/swig/src/Makefile bindings/swig/python3/Makefile tools/Makefile tools/aulast/Makefile tools/aulastlog/Makefile tools/ausyscall/Makefile m4/Makefile)
+AC_CONFIG_FILES(Makefile common/Makefile lib/Makefile lib/audit.pc lib/test/Makefile auparse/Makefile auparse/test/Makefile auparse/auparse.pc src/Makefile src/libev/Makefile src/test/Makefile docs/Makefile rules/Makefile init.d/Makefile audisp/Makefile audisp/plugins/Makefile audisp/plugins/af_unix/Makefile audisp/plugins/remote/Makefile audisp/plugins/zos-remote/Makefile audisp/plugins/syslog/Makefile audisp/plugins/filter/Makefile audisp/plugins/ids/Makefile audisp/plugins/ids/rules/Makefile audisp/plugins/statsd/Makefile bindings/Makefile bindings/python/Makefile bindings/python/python3/Makefile bindings/golang/Makefile bindings/swig/Makefile bindings/swig/src/Makefile bindings/swig/python3/Makefile tools/Makefile tools/aulast/Makefile tools/aulastlog/Makefile tools/ausyscall/Makefile m4/Makefile)
 AC_OUTPUT
 
 echo .


### PR DESCRIPTION
### Description
Audit plugins are components used in the Linux audit system to extend its functionality and customize the way audit events are processed and handled on userspace level. One common feature that all plugins lack is the ability to filter out specific events. The goal of this PR is to introduce a new plugin, capable of filtering out specific audit events based on the configuration passed to. Furthermore, it's able to forward remaining logs to the configured plugin, operating in both allowlisting and blocklisting modes.

### Implementation details
The `audisp-filter` program is accompanied by an associated config file containing `ausearch-expression(5)` s. Each line represents an  expression that can be either a simple rule or a very complex expression. These rules are grouped together using the OR operator to form one complex expression.

Once the rules are successfully loaded into an inter list of expressions, a fork happens. The parent process receives unfiltered audit events, directing them to the filtering engine. Here, audit records are searched using the expression created at the beginning. The decision to forward an audit event to the configured plugin depends on two factors: the operational mode (allowlist, blocklist) of audisp-filter and whether the expression matches the ongoing event.
On the other hand, the child process will execute the configured binary (e.g. `audisp-syslog`) and receive filtered audit events on its standard input.

Example audisp plugin configuration:
```
active = yes
direction = out
path = /sbin/audisp-filter
type = always 
args = allowlist /etc/audit/filter.conf /sbin/audisp-syslog LOG_USER LOG_INFO interpret
format = string
```

Example plugin specific configuration:
```
# Skip the openat syscall
(type r= SYSCALL && syscall i= openat)
```

I've attached a man page as well. Any  feedback will be much appreciated.