### PR TITLE
libaudit: add ausearch_cur_event

### DIFF
--- a/auparse/auparse.c
+++ b/auparse/auparse.c
@@ -1439,7 +1439,7 @@ int ausearch_cur_event(auparse_state_t* au) {
 		} else if (rc < 0)
 			return rc;
 	}
-	ausearch_reposition_cursors(au);
+
 	return 0;
 }
 

--- a/auparse/auparse.c
+++ b/auparse/auparse.c
@@ -1420,6 +1420,30 @@ static int ausearch_compare(auparse_state_t *au)
 }
 
 // Returns < 0 on error, 0 no data, > 0 success
+int ausearch_cur_event(auparse_state_t* au) {
+	int rc, records;
+
+	if (au->expr == NULL) {
+		errno = EINVAL;
+		return -1;
+	}
+
+	records = auparse_get_num_records(au);
+	for (int i = 0; i < records; i++) {
+		if (auparse_goto_record_num(au, i) != 1)
+			return -1;
+
+		if ((rc = ausearch_compare(au)) > 0) {
+			ausearch_reposition_cursors(au);
+			return 1;
+		} else if (rc < 0)
+			return rc;
+	}
+	ausearch_reposition_cursors(au);
+	return 0;
+}
+
+// Returns < 0 on error, 0 no data, > 0 success
 int ausearch_next_event(auparse_state_t *au)
 {
 	int rc;

--- a/auparse/auparse.h
+++ b/auparse/auparse.h
@@ -128,6 +128,7 @@ int auparse_normalize_key(auparse_state_t *au);
 
 /* Functions that traverse events */
 int ausearch_next_event(auparse_state_t *au);
+int ausearch_cur_event(auparse_state_t* au);
 int auparse_next_event(auparse_state_t *au);
 
 /* Accessors to event data */

--- a/auparse/test/auparse_test.c
+++ b/auparse/test/auparse_test.c
@@ -35,7 +35,7 @@ static void walk_test(auparse_state_t *au)
 		record_cnt = 1;
 		do {
 			printf("    record %d of type %d(%s) has %u fields\n",
-				record_cnt, 
+				record_cnt,
 				auparse_get_type(au),
 				audit_msg_type_to_name(auparse_get_type(au)),
 				auparse_get_num_fields(au));
@@ -79,7 +79,7 @@ void light_test(auparse_state_t *au)
 		record_cnt = 1;
 		do {
 			printf("    record %d of type %d(%s) has %u fields\n",
-				record_cnt, 
+				record_cnt,
 				auparse_get_type(au),
 				audit_msg_type_to_name(auparse_get_type(au)),
 				auparse_get_num_fields(au));
@@ -236,7 +236,7 @@ static void auparse_callback(auparse_state_t *au, auparse_cb_event_t cb_event_ty
 		record_cnt = 1;
 		do {
 			printf("    record %d of type %d(%s) has %u fields\n",
-				record_cnt, 
+				record_cnt,
 				auparse_get_type(au),
 				audit_msg_type_to_name(auparse_get_type(au)),
 				auparse_get_num_fields(au));
@@ -250,7 +250,7 @@ static void auparse_callback(auparse_state_t *au, auparse_cb_event_t cb_event_ty
 			}
 			printf("    event time: %u.%u:%lu, host=%s\n",
 					(unsigned)e->sec,
-					e->milli, e->serial, 
+					e->milli, e->serial,
 					e->host ? e->host : "?");
 			auparse_first_field(au);
 			do {
@@ -285,7 +285,7 @@ int main(void)
 			printf("%s=%s\n", auparse_get_field_name(au),
 					  auparse_get_field_str(au));
 			printf("interp auid=%s\n", auparse_interpret_field(au));
-		} else 
+		} else
 			printf("Error iterating to auid\n");
 	}
 	auparse_reset(au);
@@ -296,7 +296,7 @@ int main(void)
 					  auparse_get_field_str(au));
 			printf("interp auid=%s\n", auparse_interpret_field(au));
 			} while (auparse_find_field_next(au));
-		} else 
+		} else
 			printf("Error iterating to auid\n");
 	}
 	printf("Test 1 Done\n\n");
@@ -325,7 +325,7 @@ int main(void)
 		printf("Error - %s\n", strerror(errno));
 		return 1;
 	}
-	walk_test(au); 
+	walk_test(au);
 	auparse_destroy(au);
 	printf("Test 4 Done\n\n");
 
@@ -335,7 +335,7 @@ int main(void)
 		printf("Error - %s\n", strerror(errno));
 		return 1;
 	}
-	walk_test(au); 
+	walk_test(au);
 	auparse_destroy(au);
 	printf("Test 5 Done\n\n");
 
@@ -386,7 +386,7 @@ int main(void)
 	simple_search(AUSOURCE_FILE, AUSEARCH_STOP_EVENT);
 	auparse_destroy(au);
 	printf("Test 6 Done\n\n");
-	
+
 	printf("Starting Test 7, compound search...\n");
 	au = auparse_init(AUSOURCE_BUFFER_ARRAY, buf);
 	if (au == NULL) {
@@ -432,7 +432,7 @@ int main(void)
 				p_chunk_beg = p_chunk_end;
 			}
 		}
-		
+
 		auparse_flush_feed(au);
 		auparse_destroy(au);
 	}
@@ -458,7 +458,7 @@ int main(void)
 		while ((len = fread(buf, 1, sizeof(buf), fp))) {
 			auparse_feed(au, buf, len);
 		}
-		
+
 		fclose(fp);
 		auparse_flush_feed(au);
 		auparse_destroy(au);

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -14,7 +14,7 @@
 #
 # You should have received a copy of the GNU General Public License
 # along with this program; see the file COPYING. If not, write to the
-# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor 
+# Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor
 # Boston, MA 02110-1335, USA.
 #
 # Authors:
@@ -64,9 +64,9 @@ auparse_timestamp_compare.3 auparse_set_eoe_timeout.3 ausearch-expression.5 \
 aureport.8 ausearch.8 ausearch_add_item.3 ausearch_add_interpreted_item.3 \
 ausearch_add_expression.3 ausearch_add_timestamp_item.3 ausearch_add_regex.3 \
 ausearch_add_timestamp_item_ex.3 ausearch_clear.3 \
-ausearch_next_event.3 ausearch_set_stop.3 \
+ausearch_next_event.3 ausearch_cur_event.3 ausearch_set_stop.3 \
 get_auditfail_action.3 set_aumessage_mode.3 \
 audispd-zos-remote.8 libaudit.conf.5 \
 augenrules.8 audit_set_backlog_wait_time.3 \
-zos-remote.conf.5 
+zos-remote.conf.5
 

--- a/docs/ausearch_add_expression.3
+++ b/docs/ausearch_add_expression.3
@@ -45,7 +45,7 @@ replace it by \fB(\fIE\fB && \fIthis_search_expression\fB)\fR.
 
 .SH "RETURN VALUE"
 
-If successful, 
+If successful,
 .B ausearch_add_expression
 returns 0.
 Otherwise, it returns \-1, sets
@@ -65,6 +65,7 @@ is set to \fBNULL\fR.
 .BR ausearch_set_stop (3),
 .BR ausearch_clear (3),
 .BR ausearch_next_event (3),
+.BR ausearch_cur_event (3),
 .BR ausearch\-expression (5).
 
 .SH AUTHOR

--- a/docs/ausearch_add_interpreted_item.3
+++ b/docs/ausearch_add_interpreted_item.3
@@ -54,6 +54,7 @@ Returns \-1 if an error occurs; otherwise, 0 for success.
 .BR ausearch_set_stop (3),
 .BR ausearch_clear (3),
 .BR ausearch_next_event (3),
+.BR ausearch_cur_event (3),
 .BR ausearch\-expression (5).
 
 .SH AUTHOR

--- a/docs/ausearch_add_item.3
+++ b/docs/ausearch_add_item.3
@@ -50,10 +50,11 @@ Returns \-1 if an error occurs; otherwise, 0 for success.
 .BR ausearch_add_expression (3),
 .BR ausearch_add_interpreted_item (3),
 .BR ausearch_add_timestamp_item (3),
-.BR ausearch_add_regex (3), 
-.BR ausearch_set_stop (3), 
-.BR ausearch_clear (3), 
+.BR ausearch_add_regex (3),
+.BR ausearch_set_stop (3),
+.BR ausearch_clear (3),
 .BR ausearch_next_event (3),
+.BR ausearch_cur_event (3),
 .BR ausearch\-expression (5).
 
 .SH AUTHOR

--- a/docs/ausearch_add_regex.3
+++ b/docs/ausearch_add_regex.3
@@ -25,6 +25,7 @@ Returns \-1 if an error occurs; otherwise, 0 for success.
 .BR ausearch_add_item (3),
 .BR ausearch_clear (3),
 .BR ausearch_next_event (3),
+.BR ausearch_cur_event (3),
 .BR regcomp (3).
 
 .SH AUTHOR

--- a/docs/ausearch_add_timestamp_item.3
+++ b/docs/ausearch_add_timestamp_item.3
@@ -51,6 +51,7 @@ to add complex search expressions using a single function call.
 .BR ausearch_set_stop (3),
 .BR ausearch_clear (3),
 .BR ausearch_next_event (3),
+.BR ausearch_cur_event (3),
 .BR ausearch\-expression (5).
 
 .SH AUTHOR

--- a/docs/ausearch_add_timestamp_item_ex.3
+++ b/docs/ausearch_add_timestamp_item_ex.3
@@ -51,6 +51,7 @@ to add complex search expressions using a single function call.
 .BR ausearch_set_stop (3),
 .BR ausearch_clear (3),
 .BR ausearch_next_event (3),
+.BR ausearch_cur_event (3),
 .BR ausearch\-expression (5).
 
 .SH AUTHOR

--- a/docs/ausearch_cur_event.3
+++ b/docs/ausearch_cur_event.3
@@ -1,0 +1,25 @@
+.TH "AUSEARCH_CUR_EVENT" "3" "Feb 2024" "Red Hat" "Linux Audit API"
+.SH NAME
+ausearch_cur_event \- check if the current event meets search criteria
+.SH "SYNOPSIS"
+.B #include <auparse.h>
+.sp
+int ausearch_cur_event(auparse_state_t *au);
+
+.SH "DESCRIPTION"
+
+ausearch_cur_event will scan the input source and evaluate whether any record in the current event contains the data being searched for. Evaluation is done at the record level.
+
+.SH "RETURN VALUE"
+
+Returns \-1 if an error occurs, 0 if no matches, and 1 for success.
+
+.SH "SEE ALSO"
+
+.BR ausearch_add_item (3),
+.BR ausearch_add_regex (3),
+.BR ausearch_next_event (3),
+.BR ausearch_set_stop (3).
+
+.SH AUTHOR
+Attila Lakatos

--- a/docs/ausearch_cur_event.3
+++ b/docs/ausearch_cur_event.3
@@ -8,7 +8,7 @@ int ausearch_cur_event(auparse_state_t *au);
 
 .SH "DESCRIPTION"
 
-ausearch_cur_event will scan the input source and evaluate whether any record in the current event contains the data being searched for. Evaluation is done at the record level.
+ausearch_cur_event will scan the input source and evaluate whether any record in the current event contains the data being searched for. Evaluation is done at the record level. If a match is found, the cursor is repositioned; otherwise, it remains on the last successfully parsed record within the current event.
 
 .SH "RETURN VALUE"
 

--- a/docs/ausearch_set_stop.3
+++ b/docs/ausearch_set_stop.3
@@ -28,9 +28,10 @@ Returns \-1 if an error occurs; otherwise, 0 for success.
 
 .SH "SEE ALSO"
 
-.BR ausearch_add_item (3), 
-.BR ausearch_add_regex (3), 
-.BR ausearch_clear (3), 
+.BR ausearch_add_item (3),
+.BR ausearch_add_regex (3),
+.BR ausearch_clear (3),
+.BR ausearch_cur_event (3),
 .BR ausearch_next_event (3).
 
 .SH AUTHOR


### PR DESCRIPTION
The `ausearch_cur_event` function will scan the input source and evaluate whether any record in the current event contains the data being searched for.

The first part of `ausearch_cur_event` and `ausearch_next_event` are identical, so it can be moved to a separate function to remove duplicate code if needed.

This will help us to progress with https://github.com/linux-audit/audit-userspace/pull/352
