### PR TITLE
normalize-llist.c: fix compile error

### DIFF
--- a/auparse/normalize-llist.c
+++ b/auparse/normalize-llist.c
@@ -21,6 +21,7 @@
  *   Steve Grubb <sgrubb@redhat.com>
  */
 
+#include <stdio.h>
 #include <stdlib.h>
 #include "normalize-llist.h"
 


### PR DESCRIPTION
On Fedora 40 system, `-Wimplictit-function-declaration` error
is occur when compiling `normalize-llist.c` `printf()`.
Including `stdio.h` will fix this.

This can be applied to 3.1 branch.