### PR TITLE
Remove systemd as runtime dependecy

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,11 @@ RUNTIME DEPENDENCIES
 * kernel >= 5.0 
 * systemd
 
+NOTE: While this repository provides support for systemd to start the audit
+daemon, other init systems can be used as well. For example, [Alpine
+Linux](https://git.alpinelinux.org/aports/tree/main/audit/auditd.initd) provides
+an init script for OpenRC.
+
 BUILD-TIME DEPENDENCIES (for tar file)
 --------------------------------------
 * gcc (or clang)


### PR DESCRIPTION
Auditd does not depend on `systemd` for building and running. It only depends on `systemd` if systemd service files are used to start `auditd`. But `auditd` can be started by other init systems e.g. OpenRC as well. As done in Alpine Linux (https://git.alpinelinux.org/aports/tree/main/audit/auditd.initd)

Therefore stating `systemd` as runtime dependency is misleading.