### PR TITLE
Fix CPPCHECK_WARNING findings in auparse/ellist and ausearch-parse

### DIFF
--- a/auparse/ellist.c
+++ b/auparse/ellist.c
@@ -313,6 +313,8 @@ static int parse_up_record(rnode* r)
 						   if (nvlist_get_cnt(&r->nv)
 									 == 0)
 								free(buf);
+							// Tell static analysis tools n.name was freed
+							free(n.name);
 							return -1;
 						}
 						if (tmpctx[0]) {

--- a/src/ausearch-parse.c
+++ b/src/ausearch-parse.c
@@ -1735,14 +1735,18 @@ static int parse_sockaddr(const lnode *n, search_items *s)
 					if (s->filename) {
 						// append
 						snode sn;
+						sn.str = NULL;
 						if (un->sun_path[0])
 						    sn.str =
 							strdup(un->sun_path);
 						else if (un->sun_path[1])
 						    sn.str =
 							strdup(un->sun_path+1);
-						else
+						else {
+							// Tell static analysis tools sn.str was freed
+							free(sn.str);
 							return 6;
+						}
 
 						sn.key = NULL;
 						sn.hits = 1;


### PR DESCRIPTION
The `cppcheck` static code analysis tool reports two issues found in ausearch/auparse. Both of them seem to be false positives but it would be better to not see them.