### PR TITLE
Add subdir-objects option to automake

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,7 +38,7 @@ echo Configuring auditd $VERSION
 
 AC_CONFIG_MACRO_DIR([m4])
 AC_CANONICAL_TARGET
-AM_INIT_AUTOMAKE
+AM_INIT_AUTOMAKE([subdir-objects])
 LT_INIT
 AC_SUBST(LIBTOOL_DEPS)
 OLDLIBS="$LIBS"
@@ -123,7 +123,7 @@ AC_MSG_RESULT($DEALLOC)
 
 dnl; pthread_yield is used in zos-remote
 OLDLIBS="$LIBS"
-AC_SEARCH_LIBS(pthread_yield, pthread, 
+AC_SEARCH_LIBS(pthread_yield, pthread,
 	[AC_DEFINE(HAVE_PTHREAD_YIELD, 1, [Define to 1 if we have pthread_yield])], [])
 LIBS="$OLDLIBS"
 


### PR DESCRIPTION
I came across the following warning when inspecting the build output.  There are many unnecessary warnings regarding subdir-objects option. Details: https://www.gnu.org/software/automake/manual/html_node/List-of-Automake-options.html#index-Options_002c-subdir_002dobjects 

```
auparse/Makefile.am:92: warning: source file '../lib/gen_tables.c' is in a subdirectory,
auparse/Makefile.am:92: but option 'subdir-objects' is disabled
automake-1.16: warning: possible forward-incompatibility.
automake-1.16: At least one source file is in a subdirectory, but the 'subdir-objects'
automake-1.16: automake option hasn't been enabled.  For now, the corresponding output
automake-1.16: object file(s) will be placed in the top-level directory.  However, this
automake-1.16: behavior may change in a future Automake major version, with object
automake-1.16: files being placed in the same subdirectory as the corresponding sources.
automake-1.16: You are advised to start using 'subdir-objects' option throughout your
automake-1.16: project, to avoid future incompatibilities.
auparse/Makefile.am:668: warning: source file '../lib/gen_tables.c' is in a subdirectory,
auparse/Makefile.am:668: but option 'subdir-objects' is disabled
auparse/Makefile.am:105: warning: source file '../lib/gen_tables.c' is in a subdirectory,
auparse/Makefile.am:105: but option 'subdir-objects' is disabled
auparse/Makefile.am:118: warning: source file '../lib/gen_tables.c' is in a subdirectory,
auparse/Makefile.am:118: but option 'subdir-objects' is disabled
auparse/Makefile.am:131: warning: source file '../lib/gen_tables.c' is in a subdirectory,
auparse/Makefile.am:131: but option 'subdir-objects' is disabled
...
```