### PR TITLE
[audit-3.1-maint] Correct the auditd manpage regarding stop rules

### DIFF
--- a/docs/auditd.8
+++ b/docs/auditd.8
@@ -83,7 +83,7 @@ There is an error in the configuration file
 .B /etc/audit/plugins.d/
 - directory holding individual plugin configuration files.
 .P
-.B /etc/audit/audit-stop
+.B /etc/audit/audit-stop.rules
 - These rules are loaded when the audit daemon stops.
 .P
 .B /var/run/auditd.state


### PR DESCRIPTION
Backport the patch to 3.1 as well, source: https://github.com/linux-audit/audit-userspace/pull/387 