### PR TITLE
audit.spec: remove unsupported '--enable-systemd'

### DIFF
--- a/audit.spec
+++ b/audit.spec
@@ -102,7 +102,7 @@ The audit rules package contains the rules and utilities to load audit rules.
 %configure --with-python3=yes \
 	   --enable-gssapi-krb5=yes --with-arm --with-aarch64 \
 	   --with-libcap-ng=yes --without-golang --enable-zos-remote \
-	   --enable-systemd --enable-experimental --with-io_uring
+	   --enable-experimental --with-io_uring
 
 make CFLAGS="%{optflags}" %{?_smp_mflags}
 


### PR DESCRIPTION
Fixes: 7169631bef7c ("Update the spec file to be more correct")