### PR TITLE
ausearch-parse: fix parsing for success/uid in parse_daemon1()

### DIFF
--- a/src/ausearch-parse.c
+++ b/src/ausearch-parse.c
@@ -1549,7 +1549,9 @@ static int parse_daemon1(const lnode *n, search_items *s)
 
 	// uid - optional
 	if (event_uid != -1) {
-		ptr = term;
+		// As the uid= field may happen in different orders, e.g. both before
+		// and after pid=, let us search for the uid from the beginning.
+		term = mptr;
 		str = strstr(term, " uid=");
 		if (str) {
 			ptr = str + 5;


### PR DESCRIPTION
In `parse_daemon1()`, we may have the uid= field appear both before and after pid=, which may cause our parsing of it to fail, as we may have skipped past it. For uid=, let us search from the beginning.

Example for this case:

`type=DAEMON_END msg=audit(1709723032.140:753): op=terminate auid=0 uid=0 ses=8 pid=107086 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 res=success`

`ausearch -if sample.log -a 753 -m DAEMON_END  -ui 0 --session 8 -p 107086 --success yes`