### PR TITLE
lib/netlink: fix sending of of netlink messages in __audit_send()

### DIFF
--- a/lib/netlink.c
+++ b/lib/netlink.c
@@ -217,7 +217,7 @@ int __audit_send(int fd, int type, const void *data, unsigned int size, int *seq
 	req.nlh.nlmsg_flags = NLM_F_REQUEST|NLM_F_ACK;
 	req.nlh.nlmsg_seq = sequence;
 	if (size && data)
-		memcpy(NLMSG_DATA(&req.nlh), data, size);
+		memcpy(req.data, data, size);
 	memset(&addr, 0, sizeof(addr));
 	addr.nl_family = AF_NETLINK;
 	addr.nl_pid = 0;


### PR DESCRIPTION
While reviewing the results of coverity static analyzer, a possible OVERRUN was reported in __audit_send(), for it was passing a struct type nlmsghdr of 16 bytes to a function which accesses it at byte offset 16.

By inspecting the implementation further, we have struct audit_message with two fields, a struct nlmsghdr and a buffer:
1) struct nlmsghdr nlh
2) char data[MAX_AUDIT_MESSAGE_LENGTH]

In general, when dealing with netlink, we only need a buffer, and then we use a set of provided macros to work with it, as in We cast the buffer to a struct nlmsghdr and with this, we can use macros such as NLMSG_DATA, that indicates the beginning of the actual payload associated with the passed nlmsghdr. Another macro, NLMSG_SPACE indicates the number of bytes required for a netlink message with a given payload, and so on.

To have the static analyzer happy, this patch changes __audit_send() to use the `data' field directly.

Some food for thought: thinking more on this implementation, as we use separate fields for the header and the payload of the netlink message as if they were contiguous in memory, it seems an issue may arise if for whatever reason the compiler decides to add any padding between them, something that the C standard allows, as it makes no guarantee regarding padding inside of a struct, only that no padding should happen in the beginning of it [1] (section 6.7.2.1).

[1] https://www.open-std.org/jtc1/sc22/wg14/www/docs/n1570.pdf