### PR TITLE
Fix checkpoint issue regarding AUDIT_USER end of event detection

### DIFF
--- a/common/common.c
+++ b/common/common.c
@@ -45,6 +45,7 @@ int audit_is_last_record(int type)
 	    type == AUDIT_EOE ||
 	    (type > AUDIT_LOGIN &&
 	     type < AUDIT_FIRST_EVENT) ||
+	    type == AUDIT_USER ||
 	    type >= AUDIT_FIRST_ANOM_MSG ||
 	    type == AUDIT_KERNEL ||
 	    (type >= AUDIT_MAC_UNLBL_ALLOW &&


### PR DESCRIPTION
While consolidating the end of event function to a function, in
commit ccd4bdb, the behavior changed as some messages -- such as
AUDIT_USER messages -- were not considered anymore.

Example:

1) Before the change:
```
ts1="$(date +%T)"
touch test1.log
auditctl -m test1
ausearch -ts "${ts1}"  --checkpoint chk1

----
time->Tue Sep 10 14:45:20 2024
type=USER msg=audit(1725993920.729:2968): pid=63311 uid=0 auid=0 ses=4 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 msg='text=test1 exe="/usr/sbin/auditctl" hostname=hostname-here addr=? terminal=pts/0 res=success'
```

2) After the change (current behavior):
```
ts2="$(date +%T)"
touch test2.log
auditctl -m test2
ausearch -ts "${ts2}" --checkpoint chk2

<no matches>
```



This commit gets the previous behavior back.