### PR TITLE
Change dependency from Requires to Wants for audit-rules.service

### DIFF
--- a/init.d/auditd.service.in
+++ b/init.d/auditd.service.in
@@ -4,9 +4,9 @@ ConditionKernelCommandLine=!audit=0
 ConditionKernelCommandLine=!audit=off
 DefaultDependencies=no
 
-## The following is a "Requires" so that if rules don't load, it will
-## also fail loading the main service to be sure to get your attention.
-Requires=audit-rules.service
+## The following is a "Wants" so that if rules don't load, it will
+## not fail starting the main service. This indicates a weaker dependency.
+Wants=audit-rules.service
 
 ## If auditd is sending or receiving remote logging, copy this file to
 ## /etc/systemd/system/auditd.service and comment out the first After and


### PR DESCRIPTION
Replaced `Requires=audit-rules.service` with `Wants=audit-rules.service` in auditd.service to align with behavior from audit v4.0 and earlier. This modification ensures that if `audit-rules.service` fails to load rules into the kernel, `auditd` will not be forced to exit. This change preserves backward compatibility and prevents potential disruptions caused by issues in rule loading.