### PR TITLE
Skip plugin configs that do not have .conf suffix

### DIFF
--- a/docs/auditd-plugins.5
+++ b/docs/auditd-plugins.5
@@ -12,7 +12,7 @@ The plugin directory will be scanned and every plugin that is active will be sta
 .B max_restarts
 times as found in auditd.conf.
 
-Config file names are not allowed to have more than one '.' in the name or it will be treated as a backup copy and skipped. Config file options are given one per line with an equal sign between the keyword and its value. The available options are as follows:
+Configuration files must be regular files that do not begin with a '.' character, contain at most one '.' character, and have a '.conf' suffix. Files that do not meet these criteria will be skipped. Config file options are given one per line with an equal sign between the keyword and its value. The available options are as follows:
 
 .TP
 .I active


### PR DESCRIPTION
While the naming format for plugin configuration files is documented in the auditd-plugins(5) man page, it may appear counterintuitive and deviates from the common naming conventions followed by other widely-used components (e.g., systemd, httpd, SELinux, dracut, and others).
This patch also addresses the handling of non-regular files.

With the patch applied, plugin configurations matching the following pattern would be skipped:

- not a regular file
- hidden file
- backup file
- file without .conf suffix