### PR TITLE
audisp-filter: Traverse events correctly when forwarding

### DIFF
--- a/audisp/plugins/filter/audisp-filter.8
+++ b/audisp/plugins/filter/audisp-filter.8
@@ -38,7 +38,7 @@ Example1: Do not syslog audit events containing unsuccessful openat syscalls.
 
 First, in the plugin config, make sure that operation mode is set to allowlist, the binary points to /sbin/audispFyslog and provide any additional arguments if needed. Next, create the plugin specific config file with the content below. Before enabling the audit plugin, always make sure the syntax is correct. This can be checked by calling audisp-filter --check path/to/config/file.
 
-.B (type r= SYSCALL && syscall r= openat && success r= yes)
+.B (type r= SYSCALL && syscall i= openat && success r= yes)
 
 
 .SH FILES

--- a/audisp/plugins/filter/audisp-filter.c
+++ b/audisp/plugins/filter/audisp-filter.c
@@ -102,6 +102,7 @@ static void handle_event(auparse_state_t* au, auparse_cb_event_t cb_event_type,
 	if (forward_event) {
 		const int records = auparse_get_num_records(au);
 		for (int i = 0; i < records; i++) {
+			auparse_goto_record_num(au, i);
 			const char* txt = auparse_get_record_text(au);
 
 			// Need to add new line character to signal end of the current record


### PR DESCRIPTION
1. Fix the behavior of forwarding events in the filtering plugin, when looping through records.

2. Minor doc bugfix