### PR TITLE
Path normalization: fix segmentation fault for ".." handling

### DIFF
--- a/auparse/interpret.c
+++ b/auparse/interpret.c
@@ -921,10 +921,12 @@ static char *path_norm(const char *name)
 		else if (end - start == 2 && start[0] == '.' &&
 					 start[1] == '.') {
 			// Back up to previous component, ignore if root
-			if (dest > rpath + 1)
-				while ((--dest)[-1] != '/');
+			while (dest > rpath && (--dest)[-1] != '/');
 		} else {
-			if (dest != working && dest[-1] != '/')
+			// we need to insert a '/' if we are at the beginning
+			// and the path is absolute or we've found the next component
+			if ((dest == working && name[0] == '/') ||
+				(dest == working || dest[-1] != '/'))
 				*dest++ = '/';
 
 			// If it will overflow, chop it at last component


### PR DESCRIPTION
When a path contains ".." character, it requires normalization to resolve these. However, certain cases caused unexpected behavior, resulting in segmentation faults due to invalid memory access.
In `path_norm`, when encountering `".."`, the function attempts to backtrack to the previous `"/"` character. This approach failed when the leading `"/"` characters were removed earlier in the function, causing out-of-bounds memory access.
This fix ensures proper handling of ".." by adjusting the backtracking logic to account for removed leading slashes, preventing segmentation faults.

Steps to reproduce the original issue: Pass `"/root/../some-path"` into `path_norm` as an argument.