### PR TITLE
Correct printf format specifier as per issue 406

### DIFF
--- a/auparse/auparse.c
+++ b/auparse/auparse.c
@@ -364,7 +364,7 @@ void print_list_t(event_list_t *l)
 		printf("\n");
 		return;
 	}
-	printf("0x%p: %ld.%3.3u:%lu %s", l, l->e.sec, l->e.milli,
+	printf("0x%p: %lld.%3.3u:%lu %s", l, (long long int)l->e.sec, l->e.milli,
 			l->e.serial, l->e.host ? l->e.host : "");
 	printf(" cnt=%u", l->cnt);
 	for (r = l->head; r != NULL; r = r->next) {

--- a/src/ausearch-checkpt.c
+++ b/src/ausearch-checkpt.c
@@ -137,9 +137,9 @@ void save_ChkPt(const char *fn)
 	// Write the inode in decimal to make ls -i easier to use.
 	fprintf(fd, "dev=0x%" PRIX64 "\ninode=%" PRIu64 "\n",
 		(uint64_t)checkpt_dev, (uint64_t)checkpt_ino);
-	fprintf(fd, "output=%s %lu.%03u:%lu 0x%X\n",
+	fprintf(fd, "output=%s %lld.%03u:%lu 0x%X\n",
 		last_event.node ? last_event.node : "-",
-		(long unsigned int)last_event.sec, last_event.milli,
+		(long long int)last_event.sec, last_event.milli,
 		last_event.serial, last_event.type);
 	fclose(fd);
 }
@@ -262,9 +262,9 @@ int load_ChkPt(const char *fn)
 	{
 		fprintf(stderr, "Loaded %s - dev: 0x%X, ino: 0x%X\n",
 			fn, chkpt_input_dev, chkpt_input_ino);
-		fprintf(stderr, "output:%s %d.%03d:%lu 0x%X\n",
+		fprintf(stderr, "output:%s %lld.%03d:%lu 0x%X\n",
 			chkpt_input_levent.node ? chkpt_input_levent.node : "-",
-			chkpt_input_levent.sec, chkpt_input_levent.milli,
+			(long long int)chkpt_input_levent.sec, chkpt_input_levent.milli,
 			chkpt_input_levent.serial, chkpt_input_levent.type);
 	}
 #endif	/* DBG */

--- a/src/ausearch.c
+++ b/src/ausearch.c
@@ -441,11 +441,11 @@ static int chkpt_output_decision(event * e)
 	 */
 	if ( (chkpt_input_levent.sec < e->sec) &&
 		((e->sec - chkpt_input_levent.sec) > MAX_EVENT_DELTA_SECS) ) {
-/*		fprintf(stderr, "%s %lu.%03u:%lu vs %s %lu.%03u:%lu\n",
+/*		fprintf(stderr, "%s %lld.%03u:%lu vs %s %lld.%03u:%lu\n",
 			chkpt_input_levent.host ? chkpt_input_levent.host : "-",
-			chkpt_input_levent.sec, chkpt_input_levent.milli,
+			(long long int)chkpt_input_levent.sec, chkpt_input_levent.milli,
 			chkpt_input_levent.serial,
-			e->host, e->sec, e->milli, e->serial); */
+			e->host, (long long int)e->sec, e->milli, e->serial); */
 		return 3;
 	}
 


### PR DESCRIPTION
Need to set the format specifier of %lld for some prints of an event's seconds value as time_t is now int64_t. In case of back porting to a 32 bit time_t, the output is caste to (long long int) when printing.