### PR TITLE
time_t: use portable format specifiers for printing

### DIFF
--- a/src/ausearch-checkpt.c
+++ b/src/ausearch-checkpt.c
@@ -25,12 +25,7 @@
 #include "ausearch-checkpt.h"
 
 #define	DBG	0	/* set to non-zero for debug */
-#if SIZEOF_LONG < SIZEOF_TIME_T
-#define TIME_T_SPECIFIER "%lld"
-#else
-#define TIME_T_SPECIFIER "%ld"
-#endif
-
+#define TIME_T_SPECIFIER "%" PRIdMAX
 /* Remember why we failed */
 unsigned checkpt_failure = 0;
 


### PR DESCRIPTION
Replaced the platform-specific logic for scanning/printing time_t with the PRIdMAX macro from <inttypes.h>.