### PR TITLE
ausearch format: Fix display of renamed file

### DIFF
--- a/auparse/normalize.c
+++ b/auparse/normalize.c
@@ -693,7 +693,20 @@ static int normalize_syscall(auparse_state_t *au, const char *syscall)
 		case NORM_FILE_RENAME:
 			act = "renamed";
 			D.thing.what = NORM_WHAT_FILE; // this gets overridden
-			set_prime_object2(au, "name", 4);
+			/* A sucessfull syscall from the rename family will provide
+			 * the following items:
+			 *  0 - new dir, in which the file will be located
+			 *  1 - old dir, in which the file was located
+			 *  2 - old name, the name of the original file
+			 * 	if the file was already present in the new dir:
+			 *   3 - removal of the new file
+			 *   4 - creation of the new file
+			 *  otherwise:
+			 *  3 - creation of the new file
+			 */
+
+			// The 3rd record will always contain the name of the new file
+			set_prime_object2(au, "name", 3);
 			set_file_object(au, 2); // Thing renamed is 2 after
 			simple_file_attr(au);
 			break;


### PR DESCRIPTION
In some cases, ausearch was not correctly showing the new name of a renamed file when searching for audit events. If the target file didn’t exist prior to the rename, ausearch was unable to parse the new file name. This occurred because  ausearch attempted to retrieve this information from the 7th record, which is absent when the target file does not exist.

Before patch:
```
At 08:37:22 10/18/2024 alakatos successfully renamed /home/alakatos/github/audit-userspace/test/r-r using /home/alakatos/github/audit-userspace/test/main
```

After patch:
```
At 08:37:22 10/18/2024 alakatos successfully renamed /home/alakatos/github/audit-userspace/test/r-r to /home/alakatos/github/audit-userspace/test/r-r.renamed using /home/alakatos/github/audit-userspace/test/main
```
The same goes for the csv output.

This will not fully fix the `rename` sycall "formatting problem". If the syscall is not successful, the output will still not be correct. But that will be part of another patch.