### PR TITLE
Log runlevel changes to console (during boot)

### DIFF
--- a/audisp/Makefile.am
+++ b/audisp/Makefile.am
@@ -23,7 +23,7 @@
 
 SUBDIRS = plugins 
 CONFIG_CLEAN_FILES = *.rej *.orig
-AM_CPPFLAGS = -D_GNU_SOURCE -fPIC -DPIC -I${top_srcdir} -I${top_srcdir}/lib -I${top_srcdir}/src -I${top_srcdir}/src/libev
+AM_CPPFLAGS = -D_GNU_SOURCE -fPIC -DPIC -I${top_srcdir} -I${top_srcdir}/lib -I${top_srcdir}/src -I${top_srcdir}/src/libev -I${top_srcdir}/common
 LIBS = ${top_builddir}/lib/libaudit.la
 LDADD = -lpthread
 

--- a/audisp/plugins/remote/audisp-remote.c
+++ b/audisp/plugins/remote/audisp-remote.c
@@ -209,6 +209,9 @@ static void change_runlevel(const char *level)
 	char *argv[3];
 	int pid;
 
+	// Log runlevel changes to console
+	write_to_console("audit: changing runlevel to %s\n", level);
+
 	pid = fork();
 	if (pid < 0) {
 		syslog(LOG_ALERT,

--- a/audisp/plugins/remote/audisp-remote.c
+++ b/audisp/plugins/remote/audisp-remote.c
@@ -209,8 +209,10 @@ static void change_runlevel(const char *level)
 	char *argv[3];
 	int pid;
 
-	// Log runlevel changes to console
-	write_to_console("audit: changing runlevel to %s\n", level);
+	// In case of halt, we need to log the message before we halt
+	if (strcmp(level, HALT) == 0) {
+		write_to_console("audit: will try to change runlevel to %s\n", level);
+	}
 
 	pid = fork();
 	if (pid < 0) {
@@ -218,8 +220,21 @@ static void change_runlevel(const char *level)
 		       "audisp-remote failed to fork switching runlevels");
 		return;
 	}
-	if (pid)	/* Parent */
+	if (pid) { /* Parent */
+		int status;
+
+		// Wait until child exits
+		if (waitpid(pid, &status, 0) < 0) {
+			return;
+		}
+
+		// Check if child exited normally, runlevel change was successful
+		if (WIFEXITED(status) && WEXITSTATUS(status) == 0) {
+			write_to_console("audit: changed runlevel to %s\n", level);
+		}
+
 		return;
+	}
 
 	/* Child */
 	argv[0] = (char *)INIT_PGM;

--- a/audisp/queue.c
+++ b/audisp/queue.c
@@ -29,6 +29,7 @@
 #include <stdatomic.h>
 #endif
 #include "queue.h"
+#include "common.h"
 
 static volatile event_t **q;
 static pthread_mutex_t queue_lock;
@@ -82,6 +83,9 @@ static void change_runlevel(const char *level)
 	char *argv[3];
 	int pid;
 	static const char *init_pgm = "/sbin/init";
+
+	// Log runlevel changes to console
+	write_to_console("audit: changing runlevel to %s\n", level);
 
 	pid = fork();
 	if (pid < 0) {

--- a/common/common.c
+++ b/common/common.c
@@ -22,6 +22,9 @@
 
 #include "libaudit.h"
 #include "common.h"
+#include <fcntl.h>
+#include <unistd.h>
+#include <stdio.h>
 
 /*
  * This function returns 1 if it is the last record in an event.
@@ -55,3 +58,21 @@ int audit_is_last_record(int type)
 	return 0;
 }
 
+int write_to_console(const char *fmt, ...)
+{
+	int fd;
+	int res = 1;
+	va_list args;
+
+	if ((fd = open("/dev/console", O_WRONLY)) < 0)
+		return 0;
+
+	va_start(args, fmt);
+	if (vdprintf(fd, fmt, args) < 0) {
+		res = 0;
+	}
+	va_end(args);
+	close(fd);
+
+	return res;
+}

--- a/common/common.h
+++ b/common/common.h
@@ -50,6 +50,8 @@ char *audit_strsplit_r(char *s, char **savedpp);
 char *audit_strsplit(char *s);
 int audit_is_last_record(int type);
 
+int write_to_console(const char *fmt, ...);
+
 AUDIT_HIDDEN_END
 #endif
 

--- a/common/common.h
+++ b/common/common.h
@@ -50,7 +50,12 @@ char *audit_strsplit_r(char *s, char **savedpp);
 char *audit_strsplit(char *s);
 int audit_is_last_record(int type);
 
-int write_to_console(const char *fmt, ...);
+int write_to_console(const char *fmt, ...)
+#ifdef __GNUC__
+	__attribute__((format(printf, 1, 2)));
+#else
+	;
+#endif
 
 AUDIT_HIDDEN_END
 #endif

--- a/src/auditd-event.c
+++ b/src/auditd-event.c
@@ -180,7 +180,15 @@ int init_event(struct daemon_conf *conf)
 	if (config->daemonize == D_BACKGROUND) {
 		check_log_file_size();
 		check_excess_logs();
-		check_space_left();
+		/* At this stage, auditd is not fully initialized and operational.
+		 This means we can't notify the parent process that initialization
+		 is complete. However, if space_left_action is set to SINGLE, we must
+		 avoid switching to that runlevel. Before entering the SINGLE
+		 runlevel requires auditd to finish initialization. But auditd will not
+		 start properly or signal the init system that it has started, as it is
+		 blocked by the attempt to switch to single-user mode, resulting in a
+		 deadlock. */
+		// check_space_left();
 	}
 	format_buf = (char *)malloc(FORMAT_BUF_LEN);
 	if (format_buf == NULL) {

--- a/src/auditd-event.c
+++ b/src/auditd-event.c
@@ -46,6 +46,7 @@
 #include "private.h"
 #include "auparse.h"
 #include "auparse-idata.h"
+#include "common.h"
 
 /* This is defined in auditd.c */
 extern volatile ATOMIC_INT stop;
@@ -1350,6 +1351,9 @@ static void change_runlevel(const char *level)
 	int pid;
 	struct sigaction sa;
 	static const char *init_pgm = "/sbin/init";
+
+	// Log runlevel changes to console
+	write_to_console("audit: changing runlevel to %s\n", level);
 
 	pid = fork();
 	if (pid < 0) {


### PR DESCRIPTION
Audit may initiate runlevel changes in several scenarios, such as when available disk space for audit logs becomes critically low. In these situations, audit can halt the system during boot, but without clear evidence indicating that audit was responsible for the shutdown. With the patch applied, audit will write to `/dev/console` when doing runlevel changes.

This comes in handy during boot, so sysadmins can track down the root cause of the shutdown much faster.