### PR TITLE
propagate format mode to the audisp-af_unix plugin

### DIFF
--- a/audisp/plugins/af_unix/Makefile.am
+++ b/audisp/plugins/af_unix/Makefile.am
@@ -25,7 +25,8 @@ CONFIG_CLEAN_FILES = *.rej *.orig
 CONF_FILES = af_unix.conf
 EXTRA_DIST = $(CONF_FILES) $(man_MANS)
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/lib -I${top_srcdir}/common
+AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/lib -I${top_srcdir}/common -I${top_srcdir}/audisp
+LIBS = ${top_builddir}/lib/libaudit.la
 prog_confdir = $(sysconfdir)/audit
 plugin_confdir=$(prog_confdir)/plugins.d
 plugin_conf = af_unix.conf


### PR DESCRIPTION
Since the plugin got separated into a standalone util, the the dispatcher and the plugin were not synchronized in terms of how much data they process. audisp-af_unix read less data than the dispatcher, resulting in data misalignment.

Original bug description: https://bugzilla.redhat.com/show_bug.cgi?id=2273726

There are a few approaches how this could be handled:
1. The af_unix plugin must accept "binary" as input. The output format will be determined by a new parameter: if it's set to binary, the plugin will simply forward the header and data. If it's set to string, the data will be parsed using the code from audispd.c. This is the approach implemented in the current PR.
2. The input format could be either string or binary, with the output format matching the chosen input format. However, this would require incorporating the parsing logic from audispd and audisp-conf, as well as iterating over the plugin directory to identify an active af_unix plugin. This method did not seem feasible to me, as multiple af_unix plugins could potentially exist, leading to complications. For this reason, I chose not to pursue this approach.