### PR TITLE
Add audit-tmpfiles.conf to ensure /var/lib/audit exists

### DIFF
--- a/init.d/Makefile.am
+++ b/init.d/Makefile.am
@@ -23,7 +23,8 @@
 
 CONFIG_CLEAN_FILES = *.rej *.orig
 CLEANFILES = $(BUILT_SOURCES)
-EXTRA_DIST = auditd.service.in audit-rules.service.in auditd.conf auditd.cron \
+EXTRA_DIST = auditd.service.in audit-rules.service.in  auditd.conf auditd.cron \
+	audit-tmpfiles.conf \
 	libaudit.conf auditd.condrestart \
 	auditd.reload auditd.restart auditd.resume \
 	auditd.rotate auditd.state auditd.stop audit-rules.service \
@@ -47,6 +48,7 @@ BUILT_SOURCES = auditd.service audit-rules.service
 
 install-data-hook:
 	$(INSTALL_DATA) -D -m 640 ${srcdir}/${libconfig} ${DESTDIR}${sysconfdir}
+	$(INSTALL_DATA) -m 640 -D -t ${DESTDIR}$(prefix)/lib/tmpfiles.d/audit.conf ${srcdir}/audit-tmpfiles.conf
 
 install-exec-hook:
 	mkdir -p ${DESTDIR}${initdir}

--- a/init.d/audit-tmpfiles.conf
+++ b/init.d/audit-tmpfiles.conf
@@ -1,0 +1,1 @@
+d /var/log/audit 0700 root root - -


### PR DESCRIPTION
On image based systems for many years the idea has been to have the operating system content live in `/usr` as much as possible, and synthesize data outside there via external tools. For `/var` content, systemd-tmpfiles is a go to choice for situations like this.

For more information see
xref https://gitlab.com/fedora/bootc/tracker/-/issues/50

https://issues.redhat.com/browse/RHEL-70633