### PR TITLE
Fix a few covscan findings introduced recently

### DIFF
--- a/audisp/plugins/af_unix/audisp-af_unix.c
+++ b/audisp/plugins/af_unix/audisp-af_unix.c
@@ -253,6 +253,7 @@ void read_audit_record(int ifd)
 					do {
 						rc = write(conn, str, str_len);
 					} while (rc < 0 && errno == EINTR);
+					free(str);
 				} else if (format == F_BINARY) {
 					struct iovec vec[2];
 

--- a/audisp/plugins/filter/audisp-filter.c
+++ b/audisp/plugins/filter/audisp-filter.c
@@ -426,20 +426,19 @@ int main(int argc, const char* argv[]) {
 	capng_clear(CAPNG_SELECT_BOTH);
 	if (capng_apply(CAPNG_SELECT_BOTH))
 		syslog(LOG_WARNING,
-			"%s: unable to drop capabilities, continuing with "
-			"elevated privileges",
-			argv[0]);
+			"audisp-filter: unable to drop capabilities, continuing with "
+			"elevated privileges");
 #endif
 
 	if (pipe(pipefd) == -1) {
-		syslog(LOG_ERR, "%s: unable to open a pipe (%s)",
-			argv[0], strerror(errno));
+		syslog(LOG_ERR, "audisp-filter: unable to open a pipe (%s)",
+			strerror(errno));
 		return -1;
 	}
 
 	cpid = fork();
 	if (cpid == -1) {
-		syslog(LOG_ERR, "%s: unable to create fork (%s)", argv[0], strerror(errno));
+		syslog(LOG_ERR, "audisp-filter: unable to create fork (%s)", strerror(errno));
 		return -1;
 	}
 
@@ -451,7 +450,7 @@ int main(int argc, const char* argv[]) {
 		close(pipefd[0]);
 
 		execve(config.binary, config.binary_args, NULL);
-		syslog(LOG_ERR, "%s: execve failed (%s)", argv[0], strerror(errno));
+		syslog(LOG_ERR, "audisp-filter: execve failed (%s)", strerror(errno));
 		exit(1);
 	} else {
 		/* Parent reads input and forwards data after filters have been applied
@@ -460,7 +459,7 @@ int main(int argc, const char* argv[]) {
 
 		au = auparse_init(AUSOURCE_FEED, 0);
 		if (au == NULL) {
-			syslog(LOG_ERR, "%s: failed to initialize auparse data feed", argv[0]);
+			syslog(LOG_ERR, "audisp-filter: failed to initialize auparse data feed");
 			kill(cpid, SIGTERM);
 			return -1;
 		}


### PR DESCRIPTION
Fix a few warnings/issues detected by covscan:

```
Error: RESOURCE_LEAK
audit-4.0.3/audisp/plugins/af_unix/audisp-af_unix.c:248:6: alloc_arg: "event_to_string" allocates memory that is stored into "str".
audit-4.0.3/audisp/plugins/af_unix/audisp-af_unix.c:254:7: noescape: Resource "str" is not freed or pointed-to in "write".
audit-4.0.3/audisp/plugins/af_unix/audisp-af_unix.c:256:5: leaked_storage: Variable "str" going out of scope leaks the storage it points to.
#  254|   						rc = write(conn, str, str_len);
#  255|   					} while (rc < 0 && errno == EINTR);
#  256|-> 				} else if (format == F_BINARY) {
#  257|   					struct iovec vec[2];
#  258|   
```

```
Error: STRING_SIZE
audit-4.0.3/audisp/plugins/filter/audisp-filter.c:390:32: string_size_argv: "argv" contains strings with unknown size.
audit-4.0.3/audisp/plugins/filter/audisp-filter.c:428:3: string_size: Passing string "argv[0]" of unknown size to "syslog".
#  426|   	capng_clear(CAPNG_SELECT_BOTH);
#  427|   	if (capng_apply(CAPNG_SELECT_BOTH))
#  428|-> 		syslog(LOG_WARNING,
#  429|   			"%s: unable to drop capabilities, continuing with "
#  430|   			"elevated privileges",
```

```
Error: STRING_SIZE
audit-4.0.3/audisp/plugins/filter/audisp-filter.c:390:32: string_size_argv: "argv" contains strings with unknown size.
audit-4.0.3/audisp/plugins/filter/audisp-filter.c:435:3: string_size: Passing string "argv[0]" of unknown size to "syslog".
#  433|   
#  434|   	if (pipe(pipefd) == -1) {
#  435|-> 		syslog(LOG_ERR, "%s: unable to open a pipe (%s)",
#  436|   			argv[0], strerror(errno));
#  437|   		return -1;
```

```
audit-4.0.3/audisp/plugins/filter/audisp-filter.c:390:32: string_size_argv: "argv" contains strings with unknown size.
audit-4.0.3/audisp/plugins/filter/audisp-filter.c:442:3: string_size: Passing string "argv[0]" of unknown size to "syslog".
#  440|   	cpid = fork();
#  441|   	if (cpid == -1) {
#  442|-> 		syslog(LOG_ERR, "%s: unable to create fork (%s)", argv[0], strerror(errno));
#  443|   		return -1;
#  444|   	}
```

```
audit-4.0.3/audisp/plugins/filter/audisp-filter.c:390:32: string_size_argv: "argv" contains strings with unknown size.
audit-4.0.3/audisp/plugins/filter/audisp-filter.c:454:3: string_size: Passing string "argv[0]" of unknown size to "syslog".
#  452|   
#  453|   		execve(config.binary, config.binary_args, NULL);
#  454|-> 		syslog(LOG_ERR, "%s: execve failed (%s)", argv[0], strerror(errno));
#  455|   		exit(1);
#  456|   	} else {
```

```
audit-4.0.3/audisp/plugins/filter/audisp-filter.c:390:32: string_size_argv: "argv" contains strings with unknown size.
audit-4.0.3/audisp/plugins/filter/audisp-filter.c:463:4: string_size: Passing string "argv[0]" of unknown size to "syslog".
#  461|   		au = auparse_init(AUSOURCE_FEED, 0);
#  462|   		if (au == NULL) {
#  463|-> 			syslog(LOG_ERR, "%s: failed to initialize auparse data feed", argv[0]);
#  464|   			kill(cpid, SIGTERM);
#  465|   			return -1;
```