### PR TITLE
Move $(datadir)/audit-rules into $(libdir)/audit-rules

### DIFF
--- a/audisp/plugins/ids/rules/Makefile.am
+++ b/audisp/plugins/ids/rules/Makefile.am
@@ -22,6 +22,6 @@
 
 CONFIG_CLEAN_FILES = *.rej *.orig
 EXTRA_DIST = 25-connections.rules  25-make-exec.rules  25-recon.rules  25-unpacking.rules
-rulesdir = $(datadir)/audit-rules/ids-rules
+rulesdir = $(libdir)/audit-rules/ids-rules
 dist_rules_DATA = $(EXTRA_DIST)
 

--- a/rules/Makefile.am
+++ b/rules/Makefile.am
@@ -42,6 +42,15 @@ EXTRA_DIST = 10-base-config.rules 10-no-audit.rules 11-loginuid.rules \
 70-einval.rules 71-networking.rules \
 99-finalize.rules README-rules
 
-rulesdir = $(datadir)/audit-rules
+rulesdir = $(libdir)/audit-rules
 dist_rules_DATA = $(EXTRA_DIST)
 
+# Hook to create a symlink from /usr/share/audit-rules to /usr/lib/audit-rules
+install-exec-hook:
+	$(MKDIR_P) $(DESTDIR)$(libdir)/audit-rules
+	ln -snf $(DESTDIR)$(libdir)/audit-rules $(DESTDIR)$(datadir)/audit-rules
+
+# Uninstall hook to remove the symlink and the directory
+uninstall-hook:
+	rm -f $(DESTDIR)$(datadir)/audit-rules
+	rm -rf $(DESTDIR)$(libdir)/audit-rules


### PR DESCRIPTION
The Linux Filesystem Hierarchy Standard (FHS) specifies that files under /usr/share/ should be architecture-independent. However, some distributions remove certain sample rules that are not applicable to specific architectures. As a result, the content of audit rules shipped may vary between architectures.

This patch ensures that $(datadir)/audit-rules will continue to exist as a symlink pointing to the new architecture-specific path.