### PR TITLE
auditd config: remove HALT option from space_left_action

### DIFF
--- a/docs/auditd.conf.5
+++ b/docs/auditd.conf.5
@@ -156,7 +156,7 @@ while the audit daemon is running, you should send the audit daemon SIGHUP to re
 This parameter tells the system what action to take when the system has
 detected that it is starting to get low on disk space.
 Valid values are
-.IR ignore ", " syslog ", " rotate ", " email ", " exec ", " suspend ", " single ", and " halt .
+.IR ignore ", " syslog ", " rotate ", " email ", " exec ", " suspend ", and " single .
 If set to
 .IR ignore ,
 the audit daemon does nothing.

--- a/docs/auditd.conf.5
+++ b/docs/auditd.conf.5
@@ -173,9 +173,20 @@ as well as sending the message to syslog.
 .I suspend
 will cause the audit daemon to stop writing records to the disk. The daemon will still be alive. The
 .I single
-option will cause the audit daemon to put the computer system in single user mode. The
+option will cause the audit daemon to put the computer system in single user mode. Except for rotate, it will perform this action just one time. The previously available
 .I halt
-option will cause the audit daemon to shutdown the computer system. Except for rotate, it will perform this action just one time.
+option, which would cause the audit daemon to shut down the computer system, has been deprecated and should no longer be used. It was determined that halting the system at this stage could lead to unintended consequences and is considered a bad action if selected.
+
+Disk space notifications follow a three-stage progression. The
+.I space_left_action
+is the low water mark and serves as the first warning that disk space is running low. Halting at this stage is not recommended, as it prevents administrators from taking corrective action. The next stage,
+.I admin_space_left_action,
+indicates an emergency level where immediate action is required to free up disk space. Administrators should configure critical responses for this level. Finally, the
+.I disk_full_action
+occurs when the disk is completely full. At this stage, the system may have already halted, and preemptive measures configured in earlier stages will determine the system’s behavior.
+
+
+
 .TP
 .I admin_space_left
 This is a numeric value in megabytes that tells the audit daemon when

--- a/src/auditd-config.c
+++ b/src/auditd-config.c
@@ -1034,6 +1034,11 @@ static int space_action_parser(const struct nv_pair *nv, int line,
 				if (check_exe_name(nv->option, line))
 					return 1;
 				config->space_left_exe = strdup(nv->option);
+			} else if (failure_actions[i].option == FA_HALT) {
+				audit_msg(LOG_ERR,
+					"The HALT option in space_left_action has been deprecated"
+					" to prevent system instability from premature shutdowns.");
+				return 1;
 			}
 			config->space_left_action = failure_actions[i].option;
 			return 0;
@@ -1041,6 +1046,19 @@ static int space_action_parser(const struct nv_pair *nv, int line,
 	}
 	audit_msg(LOG_ERR, "Option %s not found - line %d", nv->value, line);
 	return 1;
+}
+
+const char *failure_action_to_str(int action)
+{
+	int i;
+
+	for (i=0; failure_actions[i].name != NULL; i++) {
+		if (failure_actions[i].option == action) {
+			return failure_actions[i].name;
+		}
+	}
+
+	return "NULL";
 }
 
 // returns 0 if OK, 1 on temp error, 2 on permanent error

--- a/src/auditd-config.c
+++ b/src/auditd-config.c
@@ -1048,17 +1048,11 @@ static int space_action_parser(const struct nv_pair *nv, int line,
 	return 1;
 }
 
-const char *failure_action_to_str(int action)
+const char *failure_action_to_str(unsigned int action)
 {
-	int i;
-
-	for (i=0; failure_actions[i].name != NULL; i++) {
-		if (failure_actions[i].option == action) {
-			return failure_actions[i].name;
-		}
-	}
-
-	return "NULL";
+	if (action > FA_HALT)
+		return "unknown";
+	return failure_actions[action].name;
 }
 
 // returns 0 if OK, 1 on temp error, 2 on permanent error

--- a/src/auditd-config.h
+++ b/src/auditd-config.h
@@ -114,6 +114,6 @@ int start_config_manager(struct auditd_event *e);
 #endif
 void free_config(struct daemon_conf *config);
 
-const char *failure_action_to_str(int action);
+const char *failure_action_to_str(unsigned int action);
 
 #endif

--- a/src/auditd-config.h
+++ b/src/auditd-config.h
@@ -114,4 +114,6 @@ int start_config_manager(struct auditd_event *e);
 #endif
 void free_config(struct daemon_conf *config);
 
+const char *failure_action_to_str(int action);
+
 #endif


### PR DESCRIPTION
The previously available HALT option, which would cause the audit daemon to shut down the computer system, has been deprecated and should no longer be used. It was determined that halting the system at this stage could lead to unintended consequences and is considered a bad action if selected.