### PR TITLE
audispd-pconfig.c: don't check unnecessary write permissions

### DIFF
--- a/audisp/audispd-pconfig.c
+++ b/audisp/audispd-pconfig.c
@@ -506,9 +506,9 @@ static int sanity_check(plugin_conf_t *config, const char *file)
 				 config->path);
 			return 1;
 		}
-		if ((buf.st_mode & (S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IXGRP)) !=
-				   (S_IRUSR|S_IWUSR|S_IXUSR|S_IRGRP|S_IXGRP)) {
-			audit_msg(LOG_ERR, "%s permissions should be 0750",
+		if ((buf.st_mode & (S_IRUSR|S_IXUSR|S_IRGRP|S_IXGRP)) !=
+				   (S_IRUSR|S_IXUSR|S_IRGRP|S_IXGRP)) {
+			audit_msg(LOG_ERR, "%s permissions should be at least 0550",
 				 config->path);
 			return 1;
 		}


### PR DESCRIPTION
While trying to use `auditd` with https://github.com/threathunters-io/laurel on NixOS I was getting an error:

	/nix/store/9q60x1fc4yq5av5c5g5h2ccmkprb9h4z-laurel-0.6.4-for-auditd/bin/laurel permissions should be 0750

This is:
- on one side the issues is specific to Nix, where no `/nix/store` file has write access at all (binaries are `0555`)
- on the other side I don't expect `auditd`  to write to that binary file, therefore it should not check for write permissions at all