### PR TITLE
Broadcast a warning if a system halt is possible

### DIFF
--- a/common/common.h
+++ b/common/common.h
@@ -57,6 +57,13 @@ int write_to_console(const char *fmt, ...)
 	;
 #endif
 
+void wall_message(const char *fmt, ...)
+#ifdef __GNUC__
+	__attribute__((format(printf, 1, 2)));
+#else
+	;
+#endif
+
 AUDIT_HIDDEN_END
 #endif
 

--- a/src/auditd-event.c
+++ b/src/auditd-event.c
@@ -852,6 +852,13 @@ static void do_space_left_action(int admin)
 	}
 	next_actions = buffer;
 
+	// If space_left is reached and FA_HALT is set in any of these fields
+	// we need to inform logged in users.
+	if (config->admin_space_left_action == FA_HALT ||
+		config->disk_full_action == FA_HALT) {
+		wall_message("Audit daemon is low on disk space for logging. %s", next_actions);
+	}
+
 	switch (action)
 	{
 		case FA_IGNORE:

--- a/src/auditd-event.c
+++ b/src/auditd-event.c
@@ -856,7 +856,7 @@ static void do_space_left_action(int admin)
 	// we need to inform logged in users.
 	if (config->admin_space_left_action == FA_HALT ||
 		config->disk_full_action == FA_HALT) {
-		wall_message("The audit system is low on disk space for logging. %s", next_actions);
+		wall_message("The audit system is low on disk space and is now halting the system for admin corrective action.");
 	}
 
 	switch (action)

--- a/src/auditd-event.c
+++ b/src/auditd-event.c
@@ -856,7 +856,7 @@ static void do_space_left_action(int admin)
 	// we need to inform logged in users.
 	if (config->admin_space_left_action == FA_HALT ||
 		config->disk_full_action == FA_HALT) {
-		wall_message("Audit daemon is low on disk space for logging. %s", next_actions);
+		wall_message("The audit system is low on disk space for logging. %s", next_actions);
 	}
 
 	switch (action)


### PR DESCRIPTION
The space left action no longer supports HALT. If we reach this stage, ensure that all logged-in users are notified in case `admin_space_left_action` or `disk_space_full_action` is set to halt the system.