### PR TITLE
logging: retrieve addr and hostname fields even if not explicitly specified

### DIFF
--- a/lib/audit_logging.c
+++ b/lib/audit_logging.c
@@ -243,7 +243,8 @@ static const char *_get_hostname(const char *ttyn)
 {
 	if (ttyn && ((strncmp(ttyn, "pts", 3) == 0) ||
 		(strncmp(ttyn, "tty", 3) == 0) ||
-		(strncmp(ttyn, "/dev/tty", 8) == 0) )) {
+		(strncmp(ttyn, "/dev/tty", 8) == 0) ||
+		(strncmp(ttyn, "/dev/pts", 8) == 0) )) {
 		if (_host[0] == 0) {
 			gethostname(_host, HOSTLEN);
 			_host[HOSTLEN - 1] = 0;


### PR DESCRIPTION
If the hostname or addr fields are omitted, audit will attempt to determine them automatically. The addr can be resolved from the hostname, while the hostname can be inferred if an active TTY is present. However, hostname resolution must occur before address resolution when the hostname is also needed for address deduction.

record before:
```
type=USER_ACCT msg=audit(02/24/2025 08:27:39.767:144) : pid=1369 uid=root auid=root ses=1 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 msg='op=PAM:accounting grantors=pam_succeed_if acct=root

exe=/usr/bin/su hostname=? addr=? terminal=/dev/pts/0 res=success' 
```

record after:
```
type=USER_ACCT msg=audit(02/24/2025 08:48:43.213:236) : pid=20034 uid=root auid=root ses=1 subj=unconfined_u:unconfined_r:unconfined_t:s0-s0:c0.c1023 msg='op=PAM:accounting grantors=pam_succeed_if acct=root

exe=/usr/bin/su hostname=prereserve-1mt-rhel-10.0-20250217.4-39128-2025-02-24-11-18 addr=fe80::f816:3eff:fef6:37ec terminal=/dev/pts/0 res=success' 
```