### PR TITLE
Fix compiler warnings

### DIFF
--- a/src/auditctl.c
+++ b/src/auditctl.c
@@ -1188,8 +1188,7 @@ static int opt_mount(opt_handler_params_t *args)
 
 static int opt_trim(opt_handler_params_t *args)
 {
-	int retval = args->retval;
-	retval = audit_trim_subtrees(fd);
+	int retval = audit_trim_subtrees(fd);
 	if (retval <= 0)
 		retval = OPT_ERROR_NO_REPLY;
 	else {

--- a/src/auditctl.c
+++ b/src/auditctl.c
@@ -642,7 +642,6 @@ static int opt_continue(opt_handler_params_t *args)
 
 static int opt_status(opt_handler_params_t *args)
 {
-	int retval = args->retval;
 	if (*(args->count) > 3) {
 		audit_msg(LOG_ERR,
 			"Too many options for status command");
@@ -1189,7 +1188,6 @@ static int opt_mount(opt_handler_params_t *args)
 
 static int opt_trim(opt_handler_params_t *args)
 {
-
 	int retval = args->retval;
 	retval = audit_trim_subtrees(fd);
 	if (retval <= 0)
@@ -1198,6 +1196,7 @@ static int opt_trim(opt_handler_params_t *args)
 		args->finish = 1;
 		return OPT_SUCCESS_NO_REPLY; // success - no reply needed
 	}
+	return retval;
 }
 
 static int opt_version(opt_handler_params_t *args)


### PR DESCRIPTION
The first two are due to the nature of realloc. It's safer to use a temporary var, so rule can still hold the old ptr in case realloc fails.
The third and fourth are minor issues that crept in during my recent refactoring (sigh).

**1.**
```
libaudit.c: In function 'audit_add_watch_dir':
libaudit.c:805:17: warning: pointer 'rule_19' may be used after 'realloc' [-Wuse-after-free]
  805 |                 free(rule);
      |                 ^~~~~~~~~~
libaudit.c:803:18: note: call to 'realloc' here
  803 |         *rulep = realloc(rule, len + sizeof(*rule));
      |                  ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

**2.**
```
libaudit.c: In function 'audit_rule_fieldpair_data':
libaudit.c:1839:33: warning: pointer 'rule_335' may be used after 'realloc' [-Wuse-after-free]
 1839 |                                 free(rule);
      |                                 ^~~~~~~~~~
libaudit.c:1837:34: note: call to 'realloc' here
 1837 |                         *rulep = realloc(rule, sizeof(*rule) + rule->buflen);
```

**3.**
```
auditctl.c: In function ‘opt_status’:
auditctl.c:645:13: warning: unused variable ‘retval’ [-Wunused-variable]
  645 |         int retval = args->retval;
      |             ^~~~~~
```

**4.**
```
auditctl.c: In function ‘opt_trim’:
auditctl.c:1201:1: warning: control reaches end of non-void function [-Wreturn-type]
 1201 | }
      | ^
```