### PR TITLE
Fix compilation errors

### DIFF
--- a/src/auditd-event.c
+++ b/src/auditd-event.c
@@ -875,6 +875,7 @@ static void do_space_left_action(int admin)
 			}
 			break;
 		case FA_EMAIL:
+		{
 			char content[512];
 			const char *subject;
 
@@ -894,6 +895,7 @@ static void do_space_left_action(int admin)
 			sendmail(subject, content, config->action_mail_acct);
 			audit_msg(LOG_ALERT, "%s", content);
 			break;
+		}
 		case FA_EXEC:
 			// Close the logging file in case the script zips or
 			// moves the file. We'll reopen in sigusr2 handler


### PR DESCRIPTION
Label case FA_EMAIL is attached to the declaration of variable `content` and `subject`. In C language declarations are not statements. They cannot be labeled. And this is what causes the error when this code is interpreted as C code
Fixes #438
Signed-off by Kirill Furman <kir.furman@gmail.com>