### PR TITLE
test suite: replace auid=42 with auid=0

### DIFF
--- a/auparse/test/auparse_test.ref
+++ b/auparse/test/auparse_test.ref
@@ -188,7 +188,7 @@ event 4 has 3 records
         uid=0 (root)
         subj=system_u:system_r:init_t:s0 (system_u:system_r:init_t:s0)
         old-auid=4294967295 (unset)
-        auid=42 (gdm)
+        auid=0 (root)
         tty=(none) ((none))
         old-ses=4294967295 (4294967295)
         ses=1 (1)
@@ -209,7 +209,7 @@ event 4 has 3 records
         items=0 (0)
         ppid=1 (1)
         pid=2288 (2288)
-        auid=42 (gdm)
+        auid=0 (root)
         uid=0 (root)
         gid=0 (root)
         euid=0 (root)
@@ -389,7 +389,7 @@ event 4 has 3 records
         uid=0 (root)
         subj=system_u:system_r:init_t:s0 (system_u:system_r:init_t:s0)
         old-auid=4294967295 (unset)
-        auid=42 (gdm)
+        auid=0 (root)
         tty=(none) ((none))
         old-ses=4294967295 (4294967295)
         ses=1 (1)
@@ -410,7 +410,7 @@ event 4 has 3 records
         items=0 (0)
         ppid=1 (1)
         pid=2288 (2288)
-        auid=42 (gdm)
+        auid=0 (root)
         uid=0 (root)
         gid=0 (root)
         euid=0 (root)
@@ -587,7 +587,7 @@ event 11 has 3 records
         uid=0 (root)
         subj=system_u:system_r:init_t:s0 (system_u:system_r:init_t:s0)
         old-auid=4294967295 (unset)
-        auid=42 (gdm)
+        auid=0 (root)
         tty=(none) ((none))
         old-ses=4294967295 (4294967295)
         ses=1 (1)
@@ -608,7 +608,7 @@ event 11 has 3 records
         items=0 (0)
         ppid=1 (1)
         pid=2288 (2288)
-        auid=42 (gdm)
+        auid=0 (root)
         uid=0 (root)
         gid=0 (root)
         euid=0 (root)
@@ -699,7 +699,7 @@ Test 6 Done
 
 Starting Test 7, compound search...
 Found type = USER_START
-Found auid = 42
+Found auid = 0
 Test 7 Done
 
 Starting Test 8, regex search...
@@ -874,7 +874,7 @@ event 4 has 3 records
         uid=0 (root)
         subj=system_u:system_r:init_t:s0 (system_u:system_r:init_t:s0)
         old-auid=4294967295 (unset)
-        auid=42 (gdm)
+        auid=0 (root)
         tty=(none) ((none))
         old-ses=4294967295 (4294967295)
         ses=1 (1)
@@ -895,7 +895,7 @@ event 4 has 3 records
         items=0 (0)
         ppid=1 (1)
         pid=2288 (2288)
-        auid=42 (gdm)
+        auid=0 (root)
         uid=0 (root)
         gid=0 (root)
         euid=0 (root)

--- a/auparse/test/auparse_test.ref.py
+++ b/auparse/test/auparse_test.ref.py
@@ -180,7 +180,7 @@ event 4 has 3 records
         uid=0 (root)
         subj=system_u:system_r:init_t:s0 (system_u:system_r:init_t:s0)
         old-auid=4294967295 (unset)
-        auid=42 (gdm)
+        auid=0 (root)
         tty=(none) ((none))
         old-ses=4294967295 (4294967295)
         ses=1 (1)
@@ -201,7 +201,7 @@ event 4 has 3 records
         items=0 (0)
         ppid=1 (1)
         pid=2288 (2288)
-        auid=42 (gdm)
+        auid=0 (root)
         uid=0 (root)
         gid=0 (root)
         euid=0 (root)
@@ -381,7 +381,7 @@ event 4 has 3 records
         uid=0 (root)
         subj=system_u:system_r:init_t:s0 (system_u:system_r:init_t:s0)
         old-auid=4294967295 (unset)
-        auid=42 (gdm)
+        auid=0 (root)
         tty=(none) ((none))
         old-ses=4294967295 (4294967295)
         ses=1 (1)
@@ -402,7 +402,7 @@ event 4 has 3 records
         items=0 (0)
         ppid=1 (1)
         pid=2288 (2288)
-        auid=42 (gdm)
+        auid=0 (root)
         uid=0 (root)
         gid=0 (root)
         euid=0 (root)
@@ -579,7 +579,7 @@ event 11 has 3 records
         uid=0 (root)
         subj=system_u:system_r:init_t:s0 (system_u:system_r:init_t:s0)
         old-auid=4294967295 (unset)
-        auid=42 (gdm)
+        auid=0 (root)
         tty=(none) ((none))
         old-ses=4294967295 (4294967295)
         ses=1 (1)
@@ -600,7 +600,7 @@ event 11 has 3 records
         items=0 (0)
         ppid=1 (1)
         pid=2288 (2288)
-        auid=42 (gdm)
+        auid=0 (root)
         uid=0 (root)
         gid=0 (root)
         euid=0 (root)
@@ -691,7 +691,7 @@ Test 6 Done
 
 Starting Test 7, compound search...
 Found type = USER_START
-Found auid = 42
+Found auid = 0
 Test 7 Done
 
 Starting Test 8, regex search...
@@ -864,7 +864,7 @@ event 4 has 3 records
         uid=0 (root)
         subj=system_u:system_r:init_t:s0 (system_u:system_r:init_t:s0)
         old-auid=4294967295 (unset)
-        auid=42 (gdm)
+        auid=0 (root)
         tty=(none) ((none))
         old-ses=4294967295 (4294967295)
         ses=1 (1)
@@ -885,7 +885,7 @@ event 4 has 3 records
         items=0 (0)
         ppid=1 (1)
         pid=2288 (2288)
-        auid=42 (gdm)
+        auid=0 (root)
         uid=0 (root)
         gid=0 (root)
         euid=0 (root)

--- a/auparse/test/test.log
+++ b/auparse/test/test.log
@@ -4,8 +4,8 @@ type=CWD msg=audit(1170021493.977:293):  cwd="/var/spool/postfix"
 type=PATH msg=audit(1170021493.977:293): item=0 name="maildrop" inode=14911367 dev=03:07 mode=040730 ouid=890 ogid=891 rdev=00:00 obj=system_u:object_r:postfix_spool_maildrop_t:s0
 type=USER_ACCT msg=audit(1170021601.340:294): user pid=13015 uid=0 auid=4294967295 subj=system_u:system_r:crond_t:s0-s0:c0.c1023 msg='PAM: accounting acct=root : exe="/usr/sbin/crond" hostname=? addr=? terminal=cron res=success'
 type=CRED_ACQ msg=audit(1170021601.342:295): user pid=13015 uid=0 auid=4294967295 subj=system_u:system_r:crond_t:s0-s0:c0.c1023 msg='PAM: setcred acct=root : exe="/usr/sbin/crond" hostname=? addr=? terminal=cron res=success'
-type=LOGIN msg=audit(1170021601.343:296): pid=2288 uid=0 subj=system_u:system_r:init_t:s0 old-auid=4294967295 auid=42 tty=(none) old-ses=4294967295 ses=1 res=1
-type=SYSCALL msg=audit(1170021601.343:296): arch=c000003e syscall=1 success=yes exit=2 a0=8 a1=7fffa7aede20 a2=2 a3=0 items=0 ppid=1 pid=2288 auid=42 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=1 comm="(systemd)" exe="/usr/lib/systemd/systemd" subj=system_u:system_r:init_t:s0 key=(null)
+type=LOGIN msg=audit(1170021601.343:296): pid=2288 uid=0 subj=system_u:system_r:init_t:s0 old-auid=4294967295 auid=0 tty=(none) old-ses=4294967295 ses=1 res=1
+type=SYSCALL msg=audit(1170021601.343:296): arch=c000003e syscall=1 success=yes exit=2 a0=8 a1=7fffa7aede20 a2=2 a3=0 items=0 ppid=1 pid=2288 auid=0 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=1 comm="(systemd)" exe="/usr/lib/systemd/systemd" subj=system_u:system_r:init_t:s0 key=(null)
 type=PROCTITLE msg=audit(1170021601.343:296): proctitle="(systemd)"
 type=USER_START msg=audit(1170021601.344:297): user pid=13015 uid=0 auid=0 subj=system_u:system_r:crond_t:s0-s0:c0.c1023 msg='PAM: session open acct=root : exe="/usr/sbin/crond" (hostname=?, addr=?, terminal=cron res=success)'
 type=CRED_DISP msg=audit(1170021601.364:298): user pid=13015 uid=0 auid=0 subj=system_u:system_r:crond_t:s0-s0:c0.c1023 msg='PAM: setcred acct=root : exe="/usr/sbin/crond" (hostname=?, addr=?, terminal=cron res=success)'

--- a/auparse/test/test2.log
+++ b/auparse/test/test2.log
@@ -4,8 +4,8 @@ type=CWD msg=audit(1170021493.977:283):  cwd="/var/spool/postfix"
 type=PATH msg=audit(1170021493.977:283): item=0 name="maildrop" inode=14911367 dev=03:07 mode=040730 ouid=890 ogid=891 rdev=00:00 obj=system_u:object_r:postfix_spool_maildrop_t:s0
 type=USER_ACCT msg=audit(1170021601.340:284): user pid=13015 uid=0 auid=4294967295 subj=system_u:system_r:crond_t:s0-s0:c0.c1023 msg='PAM: accounting acct=root : exe="/usr/sbin/crond" hostname=? addr=? terminal=cron res=success'
 type=CRED_ACQ msg=audit(1170021601.342:285): user pid=13015 uid=0 auid=4294967295 subj=system_u:system_r:crond_t:s0-s0:c0.c1023 msg='PAM: setcred acct=root : exe="/usr/sbin/crond" hostname=? addr=? terminal=cron res=success'
-type=LOGIN msg=audit(1170021601.343:286): pid=2288 uid=0 subj=system_u:system_r:init_t:s0 old-auid=4294967295 auid=42 tty=(none) old-ses=4294967295 ses=1 res=1
-type=SYSCALL msg=audit(1170021601.343:286): arch=c000003e syscall=1 success=yes exit=2 a0=8 a1=7fffa7aede20 a2=2 a3=0 items=0 ppid=1 pid=2288 auid=42 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=1 comm="(systemd)" exe="/usr/lib/systemd/systemd" subj=system_u:system_r:init_t:s0 key=(null)
+type=LOGIN msg=audit(1170021601.343:286): pid=2288 uid=0 subj=system_u:system_r:init_t:s0 old-auid=4294967295 auid=0 tty=(none) old-ses=4294967295 ses=1 res=1
+type=SYSCALL msg=audit(1170021601.343:286): arch=c000003e syscall=1 success=yes exit=2 a0=8 a1=7fffa7aede20 a2=2 a3=0 items=0 ppid=1 pid=2288 auid=0 uid=0 gid=0 euid=0 suid=0 fsuid=0 egid=0 sgid=0 fsgid=0 tty=(none) ses=1 comm="(systemd)" exe="/usr/lib/systemd/systemd" subj=system_u:system_r:init_t:s0 key=(null)
 type=PROCTITLE msg=audit(1170021601.343:286): proctitle="(systemd)"
 type=USER_START msg=audit(1170021601.344:287): user pid=13015 uid=0 auid=0 subj=system_u:system_r:crond_t:s0-s0:c0.c1023 msg='PAM: session open acct=root : exe="/usr/sbin/crond" (hostname=?, addr=?, terminal=cron res=success)'
 type=CRED_DISP msg=audit(1170021601.364:288): user pid=13015 uid=0 auid=0 subj=system_u:system_r:crond_t:s0-s0:c0.c1023 msg='PAM: setcred acct=root : exe="/usr/sbin/crond" (hostname=?, addr=?, terminal=cron res=success)'


### PR DESCRIPTION
Executing make check, the test case expected the system to have user gdm with id of 42, which might not be true in all cases. In case the user was not present, id-to-name translation failed, thus make check exited with error.