### PR TITLE
Fix audisp-remote segfault on connection error

### DIFF
--- a/audisp/plugins/remote/audisp-remote.c
+++ b/audisp/plugins/remote/audisp-remote.c
@@ -1060,19 +1060,33 @@ static int stop_sock(void)
 	if (sock >= 0) {
 #ifdef USE_GSSAPI
 		if (USE_GSS) {
-			OM_uint32 minor_status;
-			gss_delete_sec_context(&minor_status, &my_context,
-						GSS_C_NO_BUFFER);
-			my_context = GSS_C_NO_CONTEXT;
-			krb5_cc_close(kcontext, ccache);
-			ccache = NULL;
-			krb5_kt_close(kcontext, keytab);
-			keytab = NULL;
-			krb5_free_principal(kcontext, audit_princ);
-			krb5_free_default_realm(kcontext, realm_name);
-			realm_name = NULL;
-			krb5_free_context(kcontext);
-			kcontext = NULL;
+			if (my_context != GSS_C_NO_CONTEXT) {
+				OM_uint32 minor_status;
+				gss_delete_sec_context(&minor_status, &my_context,
+							GSS_C_NO_BUFFER);
+				my_context = GSS_C_NO_CONTEXT;
+			}
+
+			if (kcontext != NULL) {
+				if (ccache != NULL) {
+					krb5_cc_close(kcontext, ccache);
+					ccache = NULL;
+				}
+				if (keytab != NULL) {
+					krb5_kt_close(kcontext, keytab);
+					keytab = NULL;
+				}
+				if (audit_princ != NULL) {
+					krb5_free_principal(kcontext, audit_princ);
+					audit_princ = NULL;
+				}
+				if (realm_name != NULL) {
+					krb5_free_default_realm(kcontext, realm_name);
+					realm_name = NULL;
+				}
+				krb5_free_context(kcontext);
+				kcontext = NULL;
+			}
 		}
 #endif
 		shutdown(sock, SHUT_RDWR);


### PR DESCRIPTION
[audisp-remote.c:stop_sock](https://github.com/linux-audit/audit-userspace/blob/v4.0.3/audisp/plugins/remote/audisp-remote.c#L1058) lacked NULL pointer checks if build configuration is with `--enable-gssapi-krb5=yes`.

If auditd is started with audisp-remote plugin active and `transport=KRB5`, the audisp-remote child crashes on connection errors with segfault in [krb5_cc_close](https://github.com/krb5/krb5/blob/e2e5f386ccf2bea1fa55ce544f43098ae2b38f89/src/lib/krb5/ccache/ccfns.c#L74) due to NULL pointer dereference. This will happen immediately at startup if the remote server is not available, or later if an already established connection breaks.

It may have been exploited as follows: auditd supervises the audisp-remote child. If it sees repeated crashes, it'll report "audisp-remote has exceeded max_restarts" (depends on config). When this state is reached, auditd stops retrying and remote forwarding remains broken even if the remote server becomes available again. In other words, temporarily disturbing the network connection sufficed to permanently break auditd forwarding.

To fix it, check pointers in stop_sock before passing them on.