### PR TITLE
Remove awk call in condrestart legacy script

### DIFF
--- a/init.d/auditd.condrestart
+++ b/init.d/auditd.condrestart
@@ -2,7 +2,7 @@
 # Helper script to provide legacy auditd service options not
 # directly supported by systemd.
 
-state=$(systemctl status auditd | awk '/Active:/ { print $2 }')
+state=$(systemctl show -P ActiveState auditd)
 if [ "$state" = "active" ] ; then
 	/sbin/auditctl --signal stop
 	/bin/systemctl start auditd


### PR DESCRIPTION
This is basically a follow up to yesterday's commit 483b03b88686c9c2088d3117394046d8d6ac3917 ("Remove awk dependency"). That commit was equivalent to a recent change in Fedora's audit package.

So another trivial but BRAVELY UNTESTED pull request.