### PR TITLE
Add foreign option to automake

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -38,7 +38,7 @@ echo Configuring auditd $VERSION
 
 AC_CONFIG_MACRO_DIR([m4])
 AC_CANONICAL_TARGET
-AM_INIT_AUTOMAKE([subdir-objects])
+AM_INIT_AUTOMAKE([subdir-objects foreign])
 LT_INIT
 AC_SUBST(LIBTOOL_DEPS)
 OLDLIBS="$LIBS"


### PR DESCRIPTION
I came across the following error when run `autoreconf -i --install`.

```
libtoolize: putting auxiliary files in '.'.
libtoolize: copying file './ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIRS, 'm4'. libtoolize: copying file 'm4/libtool.m4'
libtoolize: copying file 'm4/ltoptions.m4'
libtoolize: copying file 'm4/ltsugar.m4'
libtoolize: copying file 'm4/ltversion.m4'
libtoolize: copying file 'm4/lt~obsolete.m4'
libtoolize: Consider adding '-I m4' to ACLOCAL_AMFLAGS in Makefile.am. configure.ac:42: installing './compile'
configure.ac:41: installing './missing'
Makefile.am: error: required file './README' not found audisp/Makefile.am: installing './depcomp'
bindings/swig/src/Makefile.am:25: warning: variable 'SWIG_SOURCES' is defined but no program or bindings/swig/src/Makefile.am:25: library has 'SWIG' as canonical name (possible typo) init.d/Makefile.am:42: warning: '%'-style pattern rules are a GNU make extension autoreconf: automake failed with exit status: 1
```

Set the strictness by adding foreign option. Details: https://www.gnu.org/software/automake/manual/html_node/List-of-Automake-options.html

README file is renamed at commit d23a3b98228ed3ba3a607de83e5266d25382ea84