### PR TITLE
Fix auditd -s enable hang issue (#457)

### DIFF
--- a/src/auditd.c
+++ b/src/auditd.c
@@ -969,11 +969,11 @@ int main(int argc, char *argv[])
 		AUDIT_ATOMIC_STORE(stop, 1);
 		send_audit_event(AUDIT_DAEMON_ABORT, emsg);
 		audit_msg(LOG_ERR, "Unable to set audit pid, exiting");
+		tell_parent(FAILURE);
 		shutdown_events();
 		if (pidfile)
 			unlink(pidfile);
 		shutdown_dispatcher();
-		tell_parent(FAILURE);
 		close_pipes();
 		free_config(&config);
 		ev_default_destroy();


### PR DESCRIPTION
When the environment lacks libgcc_s.so.1, the program will abort when using the pthread_cancel function.

When executing auditd -s enable, the parent process will hang at the become_daemon function waiting for the child process to write to init_pipe[1]. The child process calls shutdown_events at line 972 in auditd.c, which in turn calls pthread_cancel. Due to the absence of libgcc_s.so.1 in the environment, the child process is terminated here, and the parent process continues to wait because it did not receive the write to init_pipe[1] from the child process, causing the program to hang.

Therefore, before calling shutdown_events, the parent process should be notified that it has already failed to ensure the parent process exits promptly.