### PR TITLE
syslog: Fix duplicate libauparse and missing libaudit in LDADD

### DIFF
--- a/audisp/plugins/syslog/Makefile.am
+++ b/audisp/plugins/syslog/Makefile.am
@@ -34,7 +34,7 @@ audisp_syslog_DEPENDENCIES = ${top_builddir}/lib/libaudit.la ${top_builddir}/aup
 audisp_syslog_SOURCES = audisp-syslog.c
 audisp_syslog_CFLAGS = -fPIE -DPIE -g -D_GNU_SOURCE -Wundef ${WFLAGS}
 audisp_syslog_LDFLAGS = -pie -Wl,-z,relro -Wl,-z,now
-audisp_syslog_LDADD = $(CAPNG_LDADD) ${top_builddir}/auparse/libauparse.la ${top_builddir}/auparse/libauparse.la
+audisp_syslog_LDADD = $(CAPNG_LDADD) ${top_builddir}/lib/libaudit.la ${top_builddir}/auparse/libauparse.la
 
 install-data-hook:
 	mkdir -p -m 0750 ${DESTDIR}${plugin_confdir}


### PR DESCRIPTION
Fixes: 1fb2ef2d (Correct all dependencies, 2025-05-31)