### PR TITLE
interpret: correctly identify embedded fields

### DIFF
--- a/src/ausearch-report.c
+++ b/src/ausearch-report.c
@@ -261,7 +261,7 @@ no_print:
 
 		// look back to last space - this is name
 		name = ptr;
-		while (*name != ' ' && name > str)
+		while (name > str && name[-1] != ' ')
 			--name;
 		*ptr++ = 0;
 


### PR DESCRIPTION
Embedded fields, e.g. from libselinux in AVC records, are currently not correctly identified due to the name having trailing whitespaces. This leads to security contexts with MCS categories to be split, e.g.:

  from

    time->Fri Jun 13 23:26:09 2025
    type=PROCTITLE msg=audit(1749849969.631:6691): proctitle=2F7573722F62696E2F706870002D66002F7661722F7777772F73697465732F6E657874636C6F75642F63726F6E2E706870
    type=SYSCALL msg=audit(1749849969.631:6691): arch=c000003e syscall=64 success=no exit=-13 a0=7ea a1=3 a2=3b6 a3=7d6a32a17460 items=0 ppid=1 pid=200718 auid=4294967295 uid=33 gid=33 euid=33 suid=33 fsuid=33 egid=33 sgid=33 fsgid=33 tty=(none) ses=4294967295 comm="php" exe="/usr/bin/php8.4" subj=system_u:system_r:nextcloudcron_t:s0:c123,c456 key=(null)
    type=AVC msg=audit(1749849969.631:6691): avc:  denied  { create } for  pid=200718 comm="php" ipc_key=2026  scontext=system_u:system_r:nextcloudcron_t:s0:c123,c456 tcontext=system_u:system_r:nextcloudcron_t:s0:c123,c456 tclass=sem permissive=0

  into

    type=PROCTITLE msg=audit(06/13/25 23:26:09.631:6691) : proctitle=/usr/bin/php -f /var/www/sites/nextcloud/cron.php
    type=SYSCALL msg=audit(06/13/25 23:26:09.631:6691) : arch=x86_64 syscall=semget success=no exit=EACCES(Permission denied) a0=0x7ea a1=0x3 a2=0x3b6 a3=0x7d6a32a17460 items=0 ppid=1 pid=200718 auid=unset uid=www-data gid=www-data euid=www-data suid=www-data fsuid=www-data egid=www-data sgid=www-data fsgid=www-data tty=(none) ses=unset comm=php exe=/usr/bin/php8.4 subj=system_u:system_r:nextcloudcron_t:s0:c123,c456 key=(null)
    type=AVC msg=audit(06/13/25 23:26:09.631:6691) : avc:  denied  { create } for  pid=200718 comm=php ipc_key=2026  scontext=system_u:system_r:nextcloudcron_t:s0:c123 c456 tcontext=system_u:system_r:nextcloudcron_t:s0:c123 c456 tclass=sem permissive=0

  (note the missing comma for scontext and tcontext in the AVC record between c123 and c456)

Ignore leading white spaces in names to correctly identify " scontext" as AUPARSE_TYPE_MAC_LABEL and avoid splitting its value on commas.