### PR TITLE
Release queue mutexes during teardown

### DIFF
--- a/audisp/plugins/zos-remote/zos-remote-queue.c
+++ b/audisp/plugins/zos-remote/zos-remote-queue.c
@@ -152,5 +152,7 @@ void destroy_queue(void)
     }
 
     free(q);
+    pthread_mutex_destroy(&queue_lock);
+    pthread_cond_destroy(&queue_nonempty);
 }
 

--- a/audisp/queue.c
+++ b/audisp/queue.c
@@ -346,6 +346,7 @@ void destroy_queue(void)
 		free((void *)q[i]);
 
 	free(q);
+	pthread_mutex_destroy(&queue_lock);
 	sem_destroy(&queue_nonempty);
 #ifdef HAVE_ATOMIC
 	/*


### PR DESCRIPTION
Destroy the queue mutex and condition variable in the zos‑remote cleanup and destroy the queue mutex in the main audisp queue destructor after freeing entries.