### PR TITLE
Flesh out Auplugin

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -22,7 +22,7 @@
 #   Rickard E. (Rik) Faith <faith@redhat.com>
 #
 
-SUBDIRS = common lib auplugin auparse audisp src/libev src tools \
+SUBDIRS = common lib auparse auplugin audisp src/libev src tools \
 	bindings init.d m4 docs rules
 EXTRA_DIST = ChangeLog AUTHORS NEWS README.md INSTALL \
 	audit.spec COPYING COPYING.LIB \

--- a/Makefile.am
+++ b/Makefile.am
@@ -22,8 +22,8 @@
 #   Rickard E. (Rik) Faith <faith@redhat.com>
 #
 
-SUBDIRS = common lib auparse auplugin audisp src/libev src tools \
-	bindings init.d m4 docs rules
+SUBDIRS = common lib auparse audisp auplugin audisp/plugins src/libev \
+	src tools bindings init.d m4 docs rules
 EXTRA_DIST = ChangeLog AUTHORS NEWS README.md INSTALL \
 	audit.spec COPYING COPYING.LIB \
 	contrib/avc_snap contrib/plugin/Makefile \

--- a/audisp/Makefile.am
+++ b/audisp/Makefile.am
@@ -21,16 +21,22 @@
 #   Steve Grubb <sgrubb@redhat.com>
 #
 
-SUBDIRS = plugins 
+SUBDIRS = .
 CONFIG_CLEAN_FILES = *.rej *.orig
 AM_CPPFLAGS = -D_GNU_SOURCE -fPIC -DPIC -I${top_srcdir} -I${top_srcdir}/lib -I${top_srcdir}/src -I${top_srcdir}/common
 
 noinst_HEADERS = audispd-pconfig.h audispd-llist.h audispd-config.h \
 	queue.h libdisp.h
-libdisp_la_SOURCES = audispd.c audispd-pconfig.c queue.c \
-	audispd-llist.c
+libdisp_la_SOURCES = audispd.c audispd-pconfig.c audispd-llist.c
 libdisp_la_CFLAGS = -fno-strict-aliasing ${WFLAGS}
 libdisp_la_LDFLAGS = -no-undefined -static
-libdisp_la_LIBADD = ${top_builddir}/lib/libaudit.la -lpthread
-libdisp_la_DEPENDENCIES = ${top_builddir}/lib/libaudit.la
-noinst_LTLIBRARIES = libdisp.la
+libdisp_la_LIBADD =  libqueue.la ${top_builddir}/common/libaucommon.la \
+	${top_builddir}/lib/libaudit.la -lpthread
+libdisp_la_DEPENDENCIES = ${top_builddir}/lib/libaudit.la \
+	${top_builddir}/common/libaucommon.la libqueue.la
+
+libqueue_la_SOURCES = queue.c
+libqueue_la_LDFLAGS = -no-undefined -static
+libqueue_la_LIBADD = ${top_builddir}/common/libaucommon.la -lpthread
+
+noinst_LTLIBRARIES = libdisp.la libqueue.la

--- a/audisp/Makefile.am
+++ b/audisp/Makefile.am
@@ -21,7 +21,7 @@
 #   Steve Grubb <sgrubb@redhat.com>
 #
 
-SUBDIRS = .
+SUBDIRS = . test
 CONFIG_CLEAN_FILES = *.rej *.orig
 AM_CPPFLAGS = -D_GNU_SOURCE -fPIC -DPIC -I${top_srcdir} -I${top_srcdir}/lib -I${top_srcdir}/src -I${top_srcdir}/common
 

--- a/audisp/plugins/af_unix/Makefile.am
+++ b/audisp/plugins/af_unix/Makefile.am
@@ -25,7 +25,8 @@ CONFIG_CLEAN_FILES = *.rej *.orig
 CONF_FILES = af_unix.conf
 EXTRA_DIST = $(CONF_FILES) $(man_MANS)
 
-AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/lib -I${top_srcdir}/audisp -I${top_srcdir}/auplugin
+AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/lib -I${top_srcdir}/audisp \
+	-I${top_srcdir}/auplugin -I${top_srcdir}/auparse
 LIBS = ${top_builddir}/lib/libaudit.la
 prog_confdir = $(sysconfdir)/audit
 plugin_confdir=$(prog_confdir)/plugins.d

--- a/audisp/plugins/af_unix/audisp-af_unix.c
+++ b/audisp/plugins/af_unix/audisp-af_unix.c
@@ -47,7 +47,6 @@
 #include "audispd-pconfig.h"
 
 #define DEFAULT_PATH "/var/run/audispd_events"
-#define MAX_AUDIT_EVENT_FRAME_SIZE (sizeof(struct audit_dispatcher_header) + MAX_AUDIT_MESSAGE_LENGTH)
 //#define DEBUG
 
 /* Global Data */

--- a/audisp/plugins/filter/Makefile.am
+++ b/audisp/plugins/filter/Makefile.am
@@ -23,7 +23,7 @@
 
 CONFIG_CLEAN_FILES = *.loT *.rej *.orig
 EXTRA_DIST = filter.conf audisp-filter.conf $(man_MANS)
-AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/lib -I${top_srcdir}/common -I${top_srcdir}/auparse
+AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/lib -I${top_srcdir}/common -I${top_srcdir}/auparse -I${top_srcdir}/auplugin
 prog_confdir = $(sysconfdir)/audit
 prog_conf = audisp-filter.conf
 plugin_confdir=$(prog_confdir)/plugins.d
@@ -31,11 +31,11 @@ plugin_conf = filter.conf
 sbin_PROGRAMS = audisp-filter
 man_MANS = audisp-filter.8
 
-audisp_filter_DEPENDENCIES = ${top_builddir}/common/libaucommon.la ${top_builddir}/auparse/libauparse.la
+audisp_filter_DEPENDENCIES = ${top_builddir}/common/libaucommon.la ${top_builddir}/auparse/libauparse.la ${top_builddir}/auplugin/libauplugin.la
 audisp_filter_SOURCES = audisp-filter.c
 audisp_filter_CFLAGS = -fPIE -DPIE -g -D_GNU_SOURCE -Wundef ${WFLAGS}
 audisp_filter_LDFLAGS = -pie -Wl,-z,relro -Wl,-z,now
-audisp_filter_LDADD = $(CAPNG_LDADD) ${top_builddir}/common/libaucommon.la ${top_builddir}/auparse/libauparse.la
+audisp_filter_LDADD = $(CAPNG_LDADD) ${top_builddir}/common/libaucommon.la ${top_builddir}/auparse/libauparse.la ${top_builddir}/auplugin/libauplugin.la
 
 install-data-hook:
 	mkdir -p -m 0750 ${DESTDIR}${plugin_confdir}

--- a/audisp/plugins/filter/audisp-filter.c
+++ b/audisp/plugins/filter/audisp-filter.c
@@ -501,7 +501,7 @@ int main(int argc, const char* argv[])
 		 */
 		close(pipefd[0]);
 
-		if (auplugin_init(0, 128)) {
+		if (auplugin_init(0, 128, AUPLUGIN_Q_IN_MEMORY, NULL)) {
 			syslog(LOG_ERR,
 			       "audisp-filter: failed to init auplugin");
 			kill(cpid, SIGTERM);

--- a/audisp/plugins/ids/ids.c
+++ b/audisp/plugins/ids/ids.c
@@ -112,12 +112,17 @@ int log_audit_event(int type, const char *text, int res)
 				      NULL, NULL, NULL, res);
 }
 
-
 /*
  * SIGTERM handler
+ *
+ * Only honor the signal if it comes from the parent process so that other
+ * tasks (cough, systemctl, cough) can't make the plugin exit without
+ * the dispatcher in agreement. Otherwise it will restart the plugin.
  */
-static void term_handler(int sig __attribute__((unused)))
+static void term_handler(int sig __attribute__((unused)), siginfo_t *info, void *ucontext)
 {
+	if (info && info->si_pid != getppid())
+		return;
         stop = 1;
 	auplugin_stop();
 }
@@ -184,14 +189,15 @@ int main(void)
 	sa.sa_flags = 0;
 	sigemptyset(&sa.sa_mask);
 	/* Set handler for the ones we care about */
-	sa.sa_handler = term_handler;
-	sigaction(SIGTERM, &sa, NULL);
 	sa.sa_handler = child_handler;
 	sigaction(SIGCHLD, &sa, NULL);
 	sa.sa_handler = hup_handler;
 	sigaction(SIGHUP, &sa, NULL);
 	sa.sa_handler = sigusr1_handler;
 	sigaction(SIGUSR1, &sa, NULL);
+	sa.sa_sigaction = term_handler;
+	sa.sa_flags = SA_SIGINFO;
+	sigaction(SIGTERM, &sa, NULL);
 	(void) umask(0177);
 
 	if (load_config(&config))

--- a/audisp/plugins/ids/ids.c
+++ b/audisp/plugins/ids/ids.c
@@ -204,7 +204,7 @@ int main(void)
 	init_accounts();
 	init_sessions();
 
-	if (auplugin_init(0, 64))
+	if (auplugin_init(0, 128, AUPLUGIN_Q_IN_MEMORY, NULL))
 		return -1;
 
 	auplugin_event_feed(handle_event, TIMER_INTERVAL, do_timer_services);

--- a/audisp/plugins/ids/ids.c
+++ b/audisp/plugins/ids/ids.c
@@ -27,13 +27,11 @@
 #include <stdlib.h>
 #include <signal.h>
 #include <string.h>
-#include <sys/select.h>
 #include <errno.h>
 #include <stdarg.h>
 #include <sys/wait.h>
 #include <sys/stat.h> // umask
 #include <unistd.h>
-#include <sys/timerfd.h>
 #include "auparse.h"
 #include "libaudit.h"
 #include "auplugin.h"
@@ -63,7 +61,7 @@ static auparse_state_t *au = NULL;
 struct ids_conf config;
 
 /* Local declarations */
-static void handle_event(auparse_state_t *au,
+static void handle_event(auparse_state_t *p,
 		auparse_cb_event_t cb_event_type, void *user_data);
 
 void my_printf(const char *fmt, ...)
@@ -121,6 +119,7 @@ int log_audit_event(int type, const char *text, int res)
 static void term_handler(int sig __attribute__((unused)))
 {
         stop = 1;
+	auplugin_stop();
 }
 
 
@@ -179,11 +178,7 @@ static void output_state(void)
 
 int main(void)
 {
-	char tmp[MAX_AUDIT_MESSAGE_LENGTH+1];
 	struct sigaction sa;
-	struct itimerspec itval;
-	int tfd;
-	fd_set read_mask;
 
 	/* Register sighandlers */
 	sa.sa_flags = 0;
@@ -209,99 +204,13 @@ int main(void)
 	init_accounts();
 	init_sessions();
 
-	/* Initialize the auparse library */
-	au = auparse_init(AUSOURCE_FEED, 0);
-	if (au == NULL) {
-		my_printf("ids is exiting due to auparse init errors");
+	if (auplugin_init(0, 64))
 		return -1;
-	}
-	auparse_set_eoe_timeout(2);
-	auparse_add_callback(au, handle_event, NULL, NULL);
 
-	init_timer_services();
-	tfd = timerfd_create (CLOCK_MONOTONIC, TFD_NONBLOCK|TFD_CLOEXEC);
-	if (tfd < 0) {
-		my_printf("ids is exiting due to timerfd_create failing");
-		return -1;
-	}
-	itval.it_interval.tv_sec = TIMER_INTERVAL;
-	itval.it_interval.tv_nsec = 0;
-	itval.it_value.tv_sec = itval.it_interval.tv_sec;
-	itval.it_value.tv_nsec = 0;
-	timerfd_settime(tfd, 0, &itval, NULL);
-
-	do {
-		int retval;
-
-		/* Handle dump_state */
-		if (dump_state)
-			output_state();
-
-		/* Load configuration */
-		if (hup)
-			reload_config();
-
-		/* Probably not needed, but maybe reload took some time?  */
-		if (stop)
-			break;
-
-		do {
-			FD_ZERO(&read_mask);
-			FD_SET(0, &read_mask);
-			FD_SET(tfd, &read_mask);
-
-			if (auparse_feed_has_data(au)) {
-				// We'll do a 1 second timeout to try to
-				// age events as quick as possible
-				struct timeval tv;
-				tv.tv_sec = 1;
-				tv.tv_usec = 0;
-				//my_printf("auparse_feed_has_data");
-				retval= select(tfd+1, &read_mask,
-					       NULL, NULL, &tv);
-			} else
-				retval= select(tfd+1, &read_mask,
-					       NULL, NULL, NULL);
-
-			/* If we timed out & have events, shake them loose */
-			if (retval == 0 && auparse_feed_has_data(au)) {
-				//my_printf("auparse_feed_age_events");
-				auparse_feed_age_events(au);
-			}
-		} while (retval == -1 && errno == EINTR && NO_ACTIONS);
-
-		/* Now the event loop */
-		 if (NO_ACTIONS && retval > 0) {
-			if (FD_ISSET(0, &read_mask)) {
-				do {
-					int len;
-					if ((len = auplugin_fgets(tmp,
-						MAX_AUDIT_MESSAGE_LENGTH,
-								0)) > 0) {
-					/*	char *buf = strndup(tmp, 40);
-					     my_printf("auparse_feed %s", buf);
-						free(buf); */
-						auparse_feed(au, tmp, len);
-					}
-				} while (auplugin_fgets_more(
-						MAX_AUDIT_MESSAGE_LENGTH));
-			}
-			if (FD_ISSET(tfd, &read_mask)) {
-				//my_printf("do_timer_services");
-				do_timer_services(TIMER_INTERVAL, tfd);
-			}
-
-		}
-		if (auplugin_fgets_eof())
-			break;
-	} while (stop == 0);
+	auplugin_event_feed(handle_event, TIMER_INTERVAL, do_timer_services);
 
 	shutdown_timer_services();
-	close(tfd);
 
-	/* Flush any accumulated events from queue */
-	auparse_flush_feed(au);
-	auparse_destroy(au);
 	destroy_sessions();
 	destroy_accounts();
 	destroy_origins();
@@ -321,7 +230,7 @@ int main(void)
 
 
 /* This function receives a single complete event from the auparse library. */
-static void handle_event(auparse_state_t *au,
+static void handle_event(auparse_state_t *p,
 		auparse_cb_event_t cb_event_type,
 		void *user_data __attribute__((unused)))
 {
@@ -329,6 +238,9 @@ static void handle_event(auparse_state_t *au,
 		return;
 
 	//my_printf("handle_event %s", auparse_get_type_name(au));
+
+	/* Save for metrics reporting */
+	au = p;
 
 	/* Do this once for all models */
 	if (auparse_normalize(au, NORM_OPT_NO_ATTRS))

--- a/audisp/plugins/ids/timer-services.c
+++ b/audisp/plugins/ids/timer-services.c
@@ -43,18 +43,11 @@ void init_timer_services(void)
 	now = time(NULL);
 }
 
-void do_timer_services(unsigned int interval, int timerfd)
+void do_timer_services(unsigned int interval)
 {
-	unsigned long long missed = 0;
+	now += interval;
 
-	ssize_t r = read(timerfd, &missed, sizeof(missed));
-	if (r != sizeof(missed) || missed == 0)
-		return;
-
-	now += interval * missed;
-
-	// Update with time if the timerfd delta gets too big
-	if (missed > 1 || labs(time(NULL) - now) > (time_t)interval)
+	if (labs(time(NULL) - now) > (time_t)interval)
 		now = time(NULL);
 
 	while (nvpair_list_find_job(&jobs, now)) {

--- a/audisp/plugins/ids/timer-services.h
+++ b/audisp/plugins/ids/timer-services.h
@@ -27,7 +27,7 @@
 typedef enum {UNLOCK_ACCOUNT, UNBLOCK_ADDRESS} jobs_t;
 
 void init_timer_services(void);
-void do_timer_services(unsigned int interval, int timerfd);
+void do_timer_services(unsigned int interval);
 int add_timer_job(jobs_t job, const char *arg, unsigned long length);
 void shutdown_timer_services(void);
 

--- a/audisp/plugins/remote/Makefile.am
+++ b/audisp/plugins/remote/Makefile.am
@@ -23,7 +23,8 @@
 
 CONFIG_CLEAN_FILES = *.loT *.rej *.orig
 EXTRA_DIST = au-remote.conf audisp-remote.conf notes.txt $(man_MANS)
-AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/lib -I${top_srcdir}/common -I${top_srcdir}/auplugin
+AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/lib -I${top_srcdir}/common \
+	-I${top_srcdir}/auplugin -I${top_srcdir}/auparse
 prog_confdir = $(sysconfdir)/audit
 prog_conf = audisp-remote.conf
 plugin_confdir=$(prog_confdir)/plugins.d

--- a/audisp/plugins/statsd/Makefile.am
+++ b/audisp/plugins/statsd/Makefile.am
@@ -22,7 +22,7 @@
 #
 CONFIG_CLEAN_FILES = *.loT *.rej *.orig
 EXTRA_DIST = au-statsd.conf audisp-statsd.conf  $(man_MANS)
-AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/lib -I${top_srcdir}/auparse -I${top_srcdir}/common
+AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/lib -I${top_srcdir}/auparse -I${top_srcdir}/common -I${top_srcdir}/auplugin
 prog_confdir = $(sysconfdir)/audit
 prog_conf = audisp-statsd.conf
 plugin_confdir=$(prog_confdir)/plugins.d
@@ -31,8 +31,11 @@ sbin_PROGRAMS = audisp-statsd
 man_MANS = audisp-statsd.8
 audisp_statsd_SOURCES = audisp-statsd.c
 audisp_statsd_CFLAGS = -g -D_GNU_SOURCE ${WFLAGS}
-audisp_statsd_LDADD = $(CAPNG_LDADD) ${top_builddir}/auparse/libauparse.la ${top_builddir}/lib/libaudit.la ${top_builddir}/common/libaucommon.la
-audisp_statsd_DEPENDENCIES = ${top_builddir}/auparse/libauparse.la ${top_builddir}/lib/libaudit.la
+audisp_statsd_LDADD = $(CAPNG_LDADD) ${top_builddir}/auparse/libauparse.la \
+       ${top_builddir}/lib/libaudit.la ${top_builddir}/common/libaucommon.la \
+       ${top_builddir}/auplugin/libauplugin.la
+audisp_statsd_DEPENDENCIES = ${top_builddir}/auparse/libauparse.la \
+       ${top_builddir}/lib/libaudit.la ${top_builddir}/auplugin/libauplugin.la
 
 install-data-hook:
 	mkdir -p -m 0750 ${DESTDIR}${plugin_confdir}

--- a/audisp/plugins/statsd/audisp-statsd.c
+++ b/audisp/plugins/statsd/audisp-statsd.c
@@ -385,7 +385,7 @@ int main(void)
 		return 1;
 	}
 
-	if (auplugin_init(0, 128)) {
+	if (auplugin_init(0, 128, AUPLUGIN_Q_IN_MEMORY, NULL)) {
 		close(audit_fd);
 		close(d.sock);
 		syslog(LOG_ERR, "failed to init auplugin");

--- a/audisp/plugins/statsd/audisp-statsd.c
+++ b/audisp/plugins/statsd/audisp-statsd.c
@@ -29,8 +29,6 @@
 #include <sys/socket.h>
 #include <netdb.h>
 #include <signal.h>
-#include <poll.h>
-#include <sys/timerfd.h>
 #include <errno.h>
 #ifdef HAVE_LIBCAP_NG
 #include <cap-ng.h>
@@ -38,7 +36,7 @@
 #include "libaudit.h"
 #include "auparse.h"
 #include "common.h"
-
+#include "auplugin.h"
 
 /* Global Definitions */
 #define STATE_REPORT "/var/run/auditd.state"
@@ -78,9 +76,6 @@ struct audit_report
 static volatile int stop = 0;
 static volatile int hup = 0;
 static int audit_fd = -1;
-static auparse_state_t *au = NULL;
-static int timer_fd = -1;
-static char msg[MAX_AUDIT_MESSAGE_LENGTH + 1];
 static struct daemon_config d;
 static struct audit_report r;
 
@@ -92,17 +87,18 @@ static void handle_event(auparse_state_t *au, auparse_cb_event_t cb_event_type,
 /*
  * SIGTERM handler: exit time
  */
-static void term_handler(int sig)
+static void term_handler(int sig __attribute__((unused)))
 {
-	stop = sig;
+	stop = 1;
+	auplugin_stop();
 }
 
 /*
  * SIGHUP handler: re-read config
  */
-static void hup_handler(int sig)
+static void hup_handler(int sig __attribute__((unused)))
 {
-	hup = sig;
+	hup = 1;
 }
 
 /*
@@ -333,13 +329,17 @@ static void send_statsd(void)
 		       d.addrlen);
 }
 
+static void statsd_timer(unsigned int interval __attribute__((unused)))
+{
+	get_kernel_status();
+	get_auditd_status();
+	send_statsd();
+	clear_report();
+}
 
 int main(void)
 {
 	struct sigaction sa;
-	struct pollfd pfd[2];
-	struct itimerspec itval;
-	int rc;
 
 	if (geteuid() != 0) {
 		fprintf(stderr, "You need to be root to run this\n");
@@ -377,74 +377,24 @@ int main(void)
 		syslog(LOG_WARNING, "audisp-statsd failed dropping capabilities, continuing with elevated priviliges");
 #endif
 
-	// Initialize auparse
 	clear_report();
-	au = auparse_init(AUSOURCE_FEED, 0);
-	if (au == NULL) {
-		close(d.sock);
-		syslog(LOG_ERR, "exiting due to auparse init errors");
-		return 1;
-	}
-	auparse_set_eoe_timeout(5);
-	auparse_add_callback(au, handle_event, NULL, NULL);
 	audit_fd = audit_open();
 	if (audit_fd < 0) {
 		close(d.sock);
 		syslog(LOG_ERR, "unable to open audit socket");
 		return 1;
 	}
-	fcntl(0, F_SETFL, O_NONBLOCK); /* Set STDIN non-blocking */
-	pfd[0].fd = 0;		// add stdin to the poll group
-	pfd[0].events = POLLIN;
 
-	// Initialize interval timer
-	timer_fd = timerfd_create (CLOCK_MONOTONIC, 0);
-	if (timer_fd < 0) {
-		syslog(LOG_ERR, "unable to open a timerfd");
+	if (auplugin_init(0, 128)) {
+		close(audit_fd);
+		close(d.sock);
+		syslog(LOG_ERR, "failed to init auplugin");
 		return 1;
 	}
-	pfd[1].fd = timer_fd;
-	pfd[1].events = POLLIN;
-	itval.it_interval.tv_sec = d.interval;
-	itval.it_interval.tv_nsec = 0;
-	itval.it_value.tv_sec = itval.it_interval.tv_sec;
-	itval.it_value.tv_nsec = 0;
-	timerfd_settime(timer_fd, 0, &itval, NULL);
 
-	// Start event loop
-	while (!stop) {
-		rc = poll(pfd, 2, -1);
-		if (rc < 0) {
-			if (errno == EINTR)
-				continue;
-		} else if (rc > 0) {
-			// timer
-			if (pfd[1].revents & POLLIN) {
-				unsigned long long missed;
-				missed=read(timer_fd, &missed, sizeof (missed));
-				// Clear any old events if possible
-				if (auparse_feed_has_data(au))
-					auparse_feed_age_events(au);
-				get_kernel_status();
-				get_auditd_status();
-				send_statsd();
-				clear_report();
-			}
-			// audit event
-			if (pfd[0].revents & POLLIN) {
-				int len;
-				while ((len = read(0, msg,
-					    MAX_AUDIT_MESSAGE_LENGTH)) > 0) {
-					msg[len] = 0;
-					auparse_feed(au, msg, len);
-				}
-			}
-		}
-	}
+	auplugin_event_feed(handle_event, d.interval, statsd_timer);
 
 	// tear down everything
-	close(timer_fd);
-	auparse_destroy(au);
 	close(audit_fd);
 	close(d.sock);
 

--- a/audisp/queue.c
+++ b/audisp/queue.c
@@ -294,19 +294,16 @@ event_t *dequeue(void)
         return e;
 }
 
-event_t *dequeue_timed(const struct timespec *abstime, int *timed_out)
+event_t *dequeue_timed(const struct timespec *timeout)
 {
 	event_t *e;
 	unsigned int n;
 
-	*timed_out = 0;
-
-	while (sem_timedwait(&queue_nonempty, abstime) == -1 && errno == EINTR)
+	while (sem_timedwait(&queue_nonempty, timeout) == -1 && errno == EINTR)
 		;
-	if (errno == ETIMEDOUT) {
-		*timed_out = 1;
+	if (errno == ETIMEDOUT)
 		return NULL;
-	}
+
 	if (AUDIT_ATOMIC_LOAD(disp_hup))
 		return NULL;
 

--- a/audisp/queue.c
+++ b/audisp/queue.c
@@ -44,12 +44,12 @@
 static volatile event_t **q;
 static pthread_mutex_t queue_lock;
 static sem_t queue_nonempty;
-#ifdef HAVE_ATOMIC
 /*
  * q_next points to the next free slot for the producer.
  * q_last points to the next item the consumer should read.
  * Both are updated atomically and wrap at q_depth.
  */
+#ifdef HAVE_ATOMIC
 static atomic_uint q_next, q_last;
 extern ATOMIC_INT disp_hup;
 #else

--- a/audisp/queue.h
+++ b/audisp/queue.h
@@ -33,7 +33,7 @@ void reset_suspended(void);
 int init_queue(unsigned int size);
 int enqueue(event_t *e, struct disp_conf *config);
 event_t *dequeue(void);
-event_t *dequeue_timed(const struct timespec *abstime, int *timed_out);
+event_t *dequeue_timed(const struct timespec *timeout);
 void nudge_queue(void);
 void increase_queue_depth(unsigned int size);
 void write_queue_state(FILE *f);

--- a/audisp/queue.h
+++ b/audisp/queue.h
@@ -24,6 +24,7 @@
 #define QUEUE_HEADER
 
 #include <stdio.h>
+#include <time.h>
 #include "libdisp.h"
 #include "audispd-config.h"
 
@@ -32,6 +33,7 @@ void reset_suspended(void);
 int init_queue(unsigned int size);
 int enqueue(event_t *e, struct disp_conf *config);
 event_t *dequeue(void);
+event_t *dequeue_timed(const struct timespec *abstime, int *timed_out);
 void nudge_queue(void);
 void increase_queue_depth(unsigned int size);
 void write_queue_state(FILE *f);

--- a/audisp/queue.h
+++ b/audisp/queue.h
@@ -1,5 +1,5 @@
 /* queue.h --
- * Copyright 2007,2018 Red Hat Inc., Durham, North Carolina.
+ * Copyright 2007,2018,2025 Red Hat Inc.
  * All Rights Reserved.
  *
  * This library is free software; you can redistribute it and/or
@@ -28,9 +28,18 @@
 #include "libdisp.h"
 #include "audispd-config.h"
 
+enum {
+	Q_IN_MEMORY = 1 << 0,
+	Q_IN_FILE   = 1 << 1,
+	Q_CREAT     = 1 << 2,
+	Q_EXCL      = 1 << 3,
+	Q_SYNC      = 1 << 4,
+	Q_RESIZE    = 1 << 5,
+};
 
 void reset_suspended(void);
 int init_queue(unsigned int size);
+int init_queue_extended(unsigned int size, int flags, const char *path);
 int enqueue(event_t *e, struct disp_conf *config);
 event_t *dequeue(void);
 event_t *dequeue_timed(const struct timespec *timeout);
@@ -39,6 +48,9 @@ void increase_queue_depth(unsigned int size);
 void write_queue_state(FILE *f);
 void resume_queue(void);
 void destroy_queue(void);
+unsigned int queue_current_depth(void);
+unsigned int queue_max_depth(void);
+int queue_overflowed_p(void);
 
 #endif
 

--- a/audisp/test/Makefile.am
+++ b/audisp/test/Makefile.am
@@ -1,0 +1,31 @@
+# Makefile.am --
+# Copyright 2025 Red Hat Inc.
+# All Rights Reserved.
+#
+# This library is free software; you can redistribute it and/or
+# modify it under the terms of the GNU Lesser General Public
+# License as published by the Free Software Foundation; either
+# version 2.1 of the License, or (at your option) any later version.
+# 
+# This library is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+# Lesser General Public License for more details.
+# 
+# You should have received a copy of the GNU Lesser General Public
+# License along with this program; see the file COPYING.lib. If not, write to
+# the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor 
+# Boston, MA 02110-1335, USA.
+# 
+# Authors:
+#   Steve Grubb <sgrubb@redhat.com>
+
+AM_CPPFLAGS = -D_GNU_SOURCE -I${top_srcdir} -I${top_srcdir}/audisp \
+	-I${top_srcdir}/common -I${top_srcdir}/src -I${top_srcdir}/lib
+check_PROGRAMS = audisp-queue-test
+TESTS = $(check_PROGRAMS)
+
+audisp_queue_test_SOURCES = test-queue.c
+audisp_queue_test_LDADD = ${top_builddir}/audisp/libqueue.la \
+	${top_builddir}/common/libaucommon.la -lpthread
+

--- a/audisp/test/test-queue.c
+++ b/audisp/test/test-queue.c
@@ -1,0 +1,244 @@
+#include "config.h"
+#include <pthread.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
+#include <sys/stat.h>
+#include "queue.h"
+#include "common.h"
+
+#ifdef HAVE_ATOMIC
+ATOMIC_INT disp_hup = 0;
+#else
+volatile ATOMIC_INT disp_hup = 0;
+#endif
+
+static event_t *make_event(const char *str)
+{
+	event_t *e = calloc(1, sizeof(*e));
+	if (!e)
+		return NULL;
+	e->hdr.ver = AUDISP_PROTOCOL_VER;
+	e->hdr.hlen = sizeof(struct audit_dispatcher_header);
+	e->hdr.type = 0;
+	e->hdr.size = strlen(str);
+	if (e->hdr.size >= MAX_AUDIT_MESSAGE_LENGTH)
+		e->hdr.size = MAX_AUDIT_MESSAGE_LENGTH - 1;
+	strncpy(e->data, str, e->hdr.size);
+	e->data[e->hdr.size] = '\0';
+	return e;
+}
+
+static int basic_test(const char *logfile)
+{
+	FILE *f = fopen(logfile, "r");
+	char buf[MAX_AUDIT_MESSAGE_LENGTH];
+	event_t *e = NULL;
+	struct disp_conf conf;
+	int rc = 1;
+
+	if (!f) {
+		fprintf(stderr, "basic_test: cannot open %s\n", logfile);
+		return rc;
+	}
+	memset(&conf, 0, sizeof(conf));
+	conf.overflow_action = O_IGNORE;
+
+	if (init_queue(16)) {
+		fprintf(stderr, "basic_test: init_queue failed\n");
+		goto out;
+	}
+
+	while (fgets(buf, sizeof(buf), f)) {
+		size_t len = strlen(buf);
+		if (len && buf[len-1] == '\n')
+			buf[len-1] = '\0';
+		e = make_event(buf);
+		if (!e || enqueue(e, &conf)) {
+			fprintf(stderr, "basic_test: enqueue failed\n");
+			goto out_q;
+		}
+		e = NULL;
+	}
+
+	rewind(f);
+	while (fgets(buf, sizeof(buf), f)) {
+		size_t len = strlen(buf);
+		if (len && buf[len-1] == '\n')
+			buf[len-1] = '\0';
+		e = dequeue();
+		if (!e) {
+			fprintf(stderr, "basic_test: queue underflow\n");
+			goto out_q;
+		}
+		if (strcmp(e->data, buf) != 0) {
+			fprintf(stderr, "basic_test: data mismatch\n");
+			goto out_free;
+		}
+		free(e);
+		e = NULL;
+	}
+	if (queue_current_depth() != 0) {
+		fprintf(stderr, "basic_test: depth not zero\n");
+		goto out_q;
+	}
+	rc = 0;
+out_free:
+	free(e);
+	e = NULL;
+out_q:
+	destroy_queue();
+out:
+	fclose(f);
+	return rc;
+}
+
+struct prod_arg {
+	const char **lines;
+	int count;
+	struct disp_conf *conf;
+};
+
+static void *producer(void *a)
+{
+	struct prod_arg *pa = a;
+	for (int i = 0; i < pa->count; i++) {
+		event_t *e = make_event(pa->lines[i % pa->count]);
+		if (e)
+			enqueue(e, pa->conf);
+	}
+	return NULL;
+}
+
+static int concurrency_test(const char *logfile)
+{
+	FILE *f = fopen(logfile, "r");
+	const char *lines[32];
+	char buf[MAX_AUDIT_MESSAGE_LENGTH];
+	int n = 0;
+	struct disp_conf conf;
+	pthread_t prod[2];
+	int consumed = 0;
+	int target;
+	int rc = 1;
+
+	if (!f) {
+		fprintf(stderr, "concurrency_test: cannot open %s\n", logfile);
+		return rc;
+	}
+	memset(&conf, 0, sizeof(conf));
+	conf.overflow_action = O_IGNORE;
+
+	while (n < 32 && fgets(buf, sizeof(buf), f)) {
+		size_t len = strlen(buf);
+		if (len && buf[len-1] == '\n')
+			buf[len-1] = '\0';
+		lines[n++] = strdup(buf);
+	}
+	fclose(f);
+	if (init_queue(8)) {
+		fprintf(stderr, "concurrency_test: init_queue failed\n");
+		goto out_lines;
+	}
+
+	struct prod_arg pa = { .lines = lines, .count = n, .conf = &conf };
+	target = n * 2;
+	pthread_create(&prod[0], NULL, producer, &pa);
+	pthread_create(&prod[1], NULL, producer, &pa);
+
+	while (consumed < target) {
+		event_t *e = dequeue();
+		if (e) {
+			consumed++;
+			free(e);
+		}
+	}
+
+	pthread_join(prod[0], NULL);
+	pthread_join(prod[1], NULL);
+
+	if (queue_current_depth() != 0) {
+		fprintf(stderr, "concurrency_test: depth not zero\n");
+		rc = 1;
+	} else {
+		rc = 0;
+	}
+	destroy_queue();
+out_lines:
+	for (int i = 0; i < n; i++)
+		free((void *)lines[i]);
+	return rc;
+}
+
+static int persist_test(const char *logfile)
+{
+	char tmp[] = "/tmp/audisp_qXXXXXX";
+	struct disp_conf conf;
+	FILE *f = fopen(logfile, "r");
+	char buf[MAX_AUDIT_MESSAGE_LENGTH];
+	struct stat st;
+	int fd, rc = 1;
+
+	if (!f) {
+		fprintf(stderr, "persist_test: cannot open %s\n", logfile);
+		return rc;
+	}
+	memset(&conf, 0, sizeof(conf));
+	conf.overflow_action = O_IGNORE;
+
+	fd = mkstemp(tmp);
+	if (fd < 0) {
+		fprintf(stderr, "persist_test: mkstemp failed\n");
+		goto out_f;
+	}
+	close(fd);
+
+	if (init_queue_extended(8, Q_IN_FILE | Q_CREAT | Q_SYNC, tmp)) {
+		fprintf(stderr, "persist_test: init_queue_extended failed\n");
+		goto out_unlink;
+	}
+
+	if (!fgets(buf, sizeof(buf), f)) {
+		fprintf(stderr, "persist_test: empty logfile\n");
+		goto out_q;
+	}
+	size_t len = strlen(buf);
+	if (len && buf[len-1] == '\n')
+		buf[len-1] = '\0';
+	event_t *e = make_event(buf);
+	if (!e || enqueue(e, &conf)) {
+		fprintf(stderr, "persist_test: enqueue failed\n");
+		goto out_q;
+	}
+	destroy_queue();
+
+	if (stat(tmp, &st) || st.st_size != (off_t)strlen(buf)) {
+		fprintf(stderr, "persist_test: file not persisted\n");
+		goto out_unlink;
+	}
+	rc = 0;
+out_q:
+	;
+out_unlink:
+	unlink(tmp);
+out_f:
+	fclose(f);
+	return rc;
+}
+
+int main(void)
+{
+	const char *srcdir = getenv("srcdir") ? getenv("srcdir") : ".";
+	char path[512];
+	snprintf(path, sizeof(path), "%s/../../auparse/test/test3.log", srcdir);
+
+	if (basic_test(path))
+		return 1;
+	if (persist_test(path))
+		return 1;
+	if (concurrency_test(path))
+		return 1;
+	return 0;
+}
+

--- a/auplugin/Makefile.am
+++ b/auplugin/Makefile.am
@@ -24,11 +24,12 @@
 SUBDIRS = test
 VERSION_INFO = 1:0
 AM_CFLAGS = -fPIC -DPIC -D_GNU_SOURCE ${WFLAGS}
-AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/lib -I${top_srcdir}/auplugin
+AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/lib -I${top_srcdir}/common -I${top_srcdir}/auparse -I${top_srcdir}/auplugin -I${top_srcdir}/audisp -I${top_srcdir}/src
 
 lib_LTLIBRARIES = libauplugin.la
 include_HEADERS = auplugin.h
 
-libauplugin_la_SOURCES = auplugin-fgets.c
+libauplugin_la_SOURCES = auplugin-fgets.c auplugin.c
 libauplugin_la_LDFLAGS = -Wl,-z,relro -version-info $(VERSION_INFO)
+libauplugin_la_LIBADD = ${top_builddir}/auparse/libauparse.la -lpthread
 

--- a/auplugin/Makefile.am
+++ b/auplugin/Makefile.am
@@ -24,12 +24,15 @@
 SUBDIRS = test
 VERSION_INFO = 1:0
 AM_CFLAGS = -fPIC -DPIC -D_GNU_SOURCE ${WFLAGS}
-AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/lib -I${top_srcdir}/common -I${top_srcdir}/auparse -I${top_srcdir}/auplugin -I${top_srcdir}/audisp -I${top_srcdir}/src
+AM_CPPFLAGS = -I${top_srcdir} -I${top_srcdir}/lib -I${top_srcdir}/common \
+	-I${top_srcdir}/auparse -I${top_srcdir}/auplugin \
+	-I${top_srcdir}/audisp -I${top_srcdir}/src
 
 lib_LTLIBRARIES = libauplugin.la
 include_HEADERS = auplugin.h
 
-libauplugin_la_SOURCES = auplugin-fgets.c auplugin.c
+libauplugin_la_SOURCES = auplugin-fgets.c auplugin.c 
 libauplugin_la_LDFLAGS = -Wl,-z,relro -version-info $(VERSION_INFO)
-libauplugin_la_LIBADD = ${top_builddir}/auparse/libauparse.la -lpthread
+libauplugin_la_LIBADD = ${top_builddir}/audisp/libqueue.la \
+	${top_builddir}/auparse/libauparse.la -lpthread
 

--- a/auplugin/auplugin.c
+++ b/auplugin/auplugin.c
@@ -90,15 +90,15 @@ static void common_inbound(void)
 
 	// Set inbound descriptor to non-blocking mode
 	fcntl(fd, F_SETFL, O_NONBLOCK);
-	FD_ZERO(&read_mask);
-	FD_SET(fd, &read_mask);
 
 	do {
 		int ret_val;
+		FD_ZERO(&read_mask);
+		FD_SET(fd, &read_mask);
 
 		// Wait for next event
 		do {
-			 ret_val = select(1, &read_mask, NULL, NULL, NULL);
+			 ret_val = select(fd+1, &read_mask, NULL, NULL, NULL);
 		} while (ret_val == -1 && errno == EINTR &&
 			 !AUDIT_ATOMIC_LOAD(stop));
 

--- a/auplugin/auplugin.c
+++ b/auplugin/auplugin.c
@@ -276,18 +276,17 @@ static void *outbound_thread_feed(void *arg)
 	while (AUDIT_ATOMIC_LOAD(stop) == 0) {
 		/* This is where we block until we have an event */
 		event_t *e;
-		int timed = 0;
 		if (timer_interval) {
 			struct timespec ts;
 
 			clock_gettime(CLOCK_REALTIME, &ts);
 			ts.tv_sec += timer_interval;
-			e = dequeue_timed(&ts, &timed);
+			e = dequeue_timed(&ts);
 		} else
 			e = dequeue();
 
 		if (e == NULL) {
-			if (timed) {
+			if (timer_interval && errno == ETIMEDOUT) {
 				if (timer_cb)
 					timer_cb(timer_interval);
 				auparse_feed_age_events(au);

--- a/auplugin/auplugin.c
+++ b/auplugin/auplugin.c
@@ -102,6 +102,12 @@ static void common_inbound(void)
 		} while (ret_val == -1 && errno == EINTR &&
 			 !AUDIT_ATOMIC_LOAD(stop));
 
+		// If a real error (shouldn't happen) log it and exit
+		if (ret_val < 0 && errno != EINTR) {
+			syslog(LOG_ERR, "select error: %m");
+			AUDIT_ATOMIC_STORE(stop, 1);
+		}
+
 		// Inbound is readable
 		if (ret_val > 0) {
 		    do {

--- a/auplugin/auplugin.c
+++ b/auplugin/auplugin.c
@@ -1,0 +1,216 @@
+/* auplugin.c -- The main interface for writin auditd plugins
+ * Copyright 2025 Red Hat Inc.
+ * All Rights Reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ *
+ * Authors:
+ *      Steve Grubb <sgrubb@redhat.com>
+ */
+
+#include "config.h"
+#include <pthread.h>
+#include <signal.h>
+#include <fcntl.h>
+#include <sys/select.h>
+#include <stdlib.h>
+#include <errno.h>
+#include <syslog.h>
+#include <string.h>
+#include "common.h"	// For ATOMICs
+#include "libdisp.h"	// For event_t
+//#include "queue.h"
+#include "auplugin.h"
+
+/* Local data */
+#ifdef HAVE_ATOMIC
+static ATOMIC_INT stop = 0;
+#else
+static volatile ATOMIC_INT stop = 0; /* Fallback when atomics are absent */
+#endif
+
+static int fd;
+static pthread_t outbound_thread;
+
+/* Local function prototypes */
+static void *outbound_thread_loop(void *arg);
+static void *outbound_thread_feed(void *arg);
+
+int auplugin_init(int inbound_fd, unsigned queue_size)
+{
+	fd = inbound_fd;
+//	init_queue(queue_size);
+
+	return 0;
+}
+
+void auplugin_stop(void)
+{
+	AUDIT_ATOMIC_STORE(stop, 1);
+}
+
+static char rx_buf[MAX_AUDIT_EVENT_FRAME_SIZE+1];
+static int common_inbound(void)
+{
+	fd_set read_mask;
+
+	// Set inbound to non-blocking mode
+	fcntl(fd, F_SETFL, O_NONBLOCK);
+	FD_ZERO(&read_mask);
+	FD_SET(fd, &read_mask);
+
+	do {
+		int ret_val;
+
+		// Wait for next event
+		do {
+			 ret_val = select(1, &read_mask, NULL, NULL, NULL);
+		} while (ret_val == -1 && errno == EINTR &&
+			 !AUDIT_ATOMIC_LOAD(stop));
+
+		// Inbound is readable
+		if (ret_val > 0) {
+		    do {
+			int len;
+			if ((len = auplugin_fgets(rx_buf,
+				    MAX_AUDIT_EVENT_FRAME_SIZE + 1,fd)) > 0) {
+				// Got one - enqueue it
+				event_t *e = (event_t *)calloc(1,
+					 sizeof(event_t));
+				if (e) {
+					strncpy(e->data, rx_buf,
+						MAX_AUDIT_MESSAGE_LENGTH);
+					e->data[MAX_AUDIT_MESSAGE_LENGTH-1] = 0;
+					e->hdr.size = len;
+					e->hdr.ver = AUDISP_PROTOCOL_VER2;
+//					enqueue(e);
+				}
+			} else if (auplugin_fgets_eof()) {
+				AUDIT_ATOMIC_STORE(stop, 1);
+				syslog(LOG_INFO, "Stopping on end of file");
+			}
+		    } while (auplugin_fgets_more(MAX_AUDIT_EVENT_FRAME_SIZE));
+		}
+	} while (!AUDIT_ATOMIC_LOAD(stop));
+
+	return 0;
+}
+
+int auplugin_event_loop(auplugin_callback_ptr callback)
+{
+	/* Create outbound thread */
+	pthread_create(&outbound_thread, NULL, outbound_thread_loop, callback);
+	pthread_detach(outbound_thread);
+
+	return common_inbound();
+}
+
+int auplugin_event_feed(auparse_callback_ptr callback)
+{
+	auparse_state_t *au = auparse_init(AUSOURCE_FEED, 0);
+        if (au == NULL) {
+                printf("plugin is exiting due to auparse init errors");
+                return -1;
+        }
+        auparse_set_eoe_timeout(2);
+        auparse_add_callback(au, callback, au, NULL);
+
+	/* Create outbound thread */
+	pthread_create(&outbound_thread, NULL, outbound_thread_feed, au);
+	pthread_detach(outbound_thread);
+
+	return common_inbound();
+}
+
+static void common_outbound_thread_init(void)
+{
+        sigset_t sigs;
+
+        /* This is a worker thread. Don't handle signals. */
+        sigemptyset(&sigs);
+        sigaddset(&sigs, SIGTERM);
+        sigaddset(&sigs, SIGHUP);
+        sigaddset(&sigs, SIGUSR1);
+        sigaddset(&sigs, SIGUSR2);
+        sigaddset(&sigs, SIGCHLD);
+        sigaddset(&sigs, SIGCONT);
+        pthread_sigmask(SIG_SETMASK, &sigs, NULL);
+}
+
+/* outbound thread - dequeue data to  */
+static void *outbound_thread_loop(void *arg)
+{
+	common_outbound_thread_init();
+	auplugin_callback_ptr callback = (auplugin_callback_ptr)arg;
+
+        /* Start event loop */
+	while (AUDIT_ATOMIC_LOAD(stop) == 0) {
+		event_t *e;
+		/* This is where we block until we have an event */
+		// If we are blocked here, how do we age events? nudge queue?
+//		e = dequeue();
+		if (e == NULL) {
+			if (AUDIT_ATOMIC_LOAD(stop))
+				break;
+		}
+		if (e->hdr.ver != AUDISP_PROTOCOL_VER2) {
+			// should never be anything but v2
+			free(e);
+			continue;
+		}
+		callback(e->data);
+		free(e);
+	}
+
+	// This side destroys the queue since it knows when it's done
+//	destroy_queue();
+
+	return NULL;
+}
+
+/* outbound thread - dequeue data to  */
+static void *outbound_thread_feed(void *arg)
+{
+	int len;
+	auparse_state_t *au  = (auparse_state_t *)arg;
+	common_outbound_thread_init();
+
+        /* Start event loop */
+	while (AUDIT_ATOMIC_LOAD(stop) == 0) {
+		event_t *e;
+		/* This is where we block until we have an event */
+		// If we are blocked here, how do we age events? nudge queue?
+//		event_t *e = dequeue();
+		if (e == NULL) {
+			if (AUDIT_ATOMIC_LOAD(stop))
+				break;
+		}
+		if (e->hdr.ver != AUDISP_PROTOCOL_VER2) {
+			// should never be anything but v2
+			free(e);
+			continue;
+		}
+		auparse_feed(au, e->data, e->hdr.size);
+		free(e);
+	}
+	auparse_flush_feed(au);
+	auparse_destroy(au);
+
+	// This side destroys the queue since it knows when it's done
+//	destroy_queue();
+
+	return NULL;
+}
+

--- a/auplugin/auplugin.c
+++ b/auplugin/auplugin.c
@@ -36,6 +36,12 @@ AUDIT_HIDDEN_START
 AUDIT_HIDDEN_END
 #include "auplugin.h"
 
+/*
+ * The library maintains global state for its queue and worker threads.
+ * Only one plugin instance is supported, so callers must not invoke
+ * auplugin_init() concurrently from multiple threads.
+ */
+
 /* Local data */
 #ifdef HAVE_ATOMIC
 static ATOMIC_INT stop = 0;

--- a/auplugin/auplugin.c
+++ b/auplugin/auplugin.c
@@ -171,7 +171,7 @@ int auplugin_event_feed(auparse_callback_ptr callback)
                 return -1;
         }
         auparse_set_eoe_timeout(2);
-        auparse_add_callback(au, callback, au, NULL);
+        auparse_add_callback(au, callback, NULL, NULL);
 
 	/* Create outbound thread */
 	pthread_create(&outbound_thread, NULL, outbound_thread_feed, au);
@@ -233,7 +233,6 @@ static void *outbound_thread_loop(void *arg)
  */
 static void *outbound_thread_feed(void *arg)
 {
-	int len;
 	auparse_state_t *au  = (auparse_state_t *)arg;
 	common_outbound_thread_init();
 

--- a/auplugin/auplugin.h
+++ b/auplugin/auplugin.h
@@ -25,6 +25,8 @@
 #define _AUPLUGIN_H_
 
 #include <stddef.h>
+#include <libaudit.h>
+#include <auparse.h>
 
 #ifndef __attr_access
 # define __attr_access(x)
@@ -40,6 +42,8 @@
 extern "C" {
 #endif
 
+#define MAX_AUDIT_EVENT_FRAME_SIZE (sizeof(struct audit_dispatcher_header) + MAX_AUDIT_MESSAGE_LENGTH)
+
 typedef struct auplugin_fgets_state auplugin_fgets_state_t;
 
 enum auplugin_mem {
@@ -47,6 +51,8 @@ enum auplugin_mem {
 	MEM_MMAP,
 	MEM_SELF_MANAGED
 };
+
+typedef void (*auplugin_callback_ptr)(const char *record);
 
 void auplugin_fgets_clear(void);
 int auplugin_fgets_eof(void);
@@ -67,6 +73,11 @@ int auplugin_fgets_r(auplugin_fgets_state_t *st, char *buf, size_t blen, int fd)
 int auplugin_setvbuf_r(auplugin_fgets_state_t *st, void *buf, size_t buff_size,
 			enum auplugin_mem how)
 			__attr_access ((__read_only__, 2, 3));
+
+int auplugin_init(int inbound_fd, unsigned queue_size);
+void auplugin_stop(void);
+int auplugin_event_loop(auplugin_callback_ptr callback);
+int auplugin_event_feed(auparse_callback_ptr callback);
 
 #ifdef __cplusplus
 }

--- a/auplugin/auplugin.h
+++ b/auplugin/auplugin.h
@@ -76,7 +76,7 @@ int auplugin_setvbuf_r(auplugin_fgets_state_t *st, void *buf, size_t buff_size,
 
 int auplugin_init(int inbound_fd, unsigned queue_size);
 void auplugin_stop(void);
-int auplugin_event_loop(auplugin_callback_ptr callback);
+void auplugin_event_loop(auplugin_callback_ptr callback);
 int auplugin_event_feed(auparse_callback_ptr callback);
 
 #ifdef __cplusplus

--- a/auplugin/auplugin.h
+++ b/auplugin/auplugin.h
@@ -52,8 +52,11 @@ enum auplugin_mem {
 	MEM_SELF_MANAGED
 };
 
+/* Callback prototypes */
 typedef void (*auplugin_callback_ptr)(const char *record);
+typedef void (*auplugin_timer_callback_ptr)(unsigned int interval);
 
+/* fgets family of functions prototypes */
 void auplugin_fgets_clear(void);
 int auplugin_fgets_eof(void);
 int auplugin_fgets_more(size_t blen);
@@ -74,11 +77,13 @@ int auplugin_setvbuf_r(auplugin_fgets_state_t *st, void *buf, size_t buff_size,
 			enum auplugin_mem how)
 			__attr_access ((__read_only__, 2, 3));
 
+/* auplugin family of functions prototypes */
 int auplugin_init(int inbound_fd, unsigned queue_size);
 void auplugin_stop(void);
 void auplugin_event_loop(auplugin_callback_ptr callback);
-int auplugin_event_feed(auparse_callback_ptr callback);
-
+int auplugin_event_feed(auparse_callback_ptr callback,
+			unsigned int timer_interval,
+			auplugin_timer_callback_ptr timer_cb);
 #ifdef __cplusplus
 }
 #endif

--- a/auplugin/auplugin.h
+++ b/auplugin/auplugin.h
@@ -52,9 +52,21 @@ enum auplugin_mem {
 	MEM_SELF_MANAGED
 };
 
+enum {
+       AUPLUGIN_Q_IN_MEMORY = 1 << 0,
+       AUPLUGIN_Q_IN_FILE   = 1 << 1,
+       AUPLUGIN_Q_CREAT     = 1 << 2,
+       AUPLUGIN_Q_EXCL      = 1 << 3,
+       AUPLUGIN_Q_SYNC      = 1 << 4,
+       AUPLUGIN_Q_RESIZE    = 1 << 5,
+};
+
 /* Callback prototypes */
 typedef void (*auplugin_callback_ptr)(const char *record);
 typedef void (*auplugin_timer_callback_ptr)(unsigned int interval);
+typedef void (*auplugin_stats_callback_ptr)(unsigned int depth,
+					    unsigned int max_depth,
+					    int overflow);
 
 /* fgets family of functions prototypes */
 void auplugin_fgets_clear(void);
@@ -78,12 +90,19 @@ int auplugin_setvbuf_r(auplugin_fgets_state_t *st, void *buf, size_t buff_size,
 			__attr_access ((__read_only__, 2, 3));
 
 /* auplugin family of functions prototypes */
-int auplugin_init(int inbound_fd, unsigned queue_size);
+int auplugin_init(int inbound_fd, unsigned queue_size, int q_flags,
+		  const char *path);
 void auplugin_stop(void);
 void auplugin_event_loop(auplugin_callback_ptr callback);
 int auplugin_event_feed(auparse_callback_ptr callback,
 			unsigned int timer_interval,
 			auplugin_timer_callback_ptr timer_cb);
+void auplugin_register_stats_callback(auplugin_stats_callback_ptr cb);
+void auplugin_report_stats(void);
+unsigned int auplugin_queue_depth(void);
+unsigned int auplugin_queue_max_depth(void);
+int auplugin_queue_overflow(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/auplugin/test/Makefile.am
+++ b/auplugin/test/Makefile.am
@@ -21,8 +21,12 @@
 #   Steve Grubb <sgrubb@redhat.com>
 
 AM_CPPFLAGS = -I${top_srcdir}/auplugin -I${top_srcdir}/lib -I${top_srcdir}/auparse
-check_PROGRAMS = fgets_test
+check_PROGRAMS = fgets_test metrics_test
 TESTS = $(check_PROGRAMS)
 
 fgets_test_LDADD = ${top_builddir}/auplugin/libauplugin.la
 fgets_test_DEPENDENCIES = ${top_builddir}/auplugin/libauplugin.la
+
+metrics_test_LDADD = ${top_builddir}/auplugin/libauplugin.la
+metrics_test_DEPENDENCIES = ${top_builddir}/auplugin/libauplugin.la
+

--- a/auplugin/test/Makefile.am
+++ b/auplugin/test/Makefile.am
@@ -20,7 +20,7 @@
 # Authors:
 #   Steve Grubb <sgrubb@redhat.com>
 
-AM_CPPFLAGS = -I${top_srcdir}/auplugin
+AM_CPPFLAGS = -I${top_srcdir}/auplugin -I${top_srcdir}/lib -I${top_srcdir}/auparse
 check_PROGRAMS = fgets_test
 TESTS = $(check_PROGRAMS)
 

--- a/auplugin/test/metrics_test.c
+++ b/auplugin/test/metrics_test.c
@@ -1,0 +1,15 @@
+#include <stdio.h>
+#include <auplugin.h>
+
+static void cb(unsigned int depth, unsigned int max, int ovf)
+{
+    printf("depth=%u max=%u ovf=%d\n", depth, max, ovf);
+}
+
+int main(void)
+{
+    auplugin_register_stats_callback(cb);
+    auplugin_report_stats();
+    return 0;
+}
+

--- a/common/common.h
+++ b/common/common.h
@@ -23,6 +23,7 @@
 #ifndef AUDIT_COMMON_HEADER
 #define AUDIT_COMMON_HEADER
 
+#include <limits.h> /* POSIX_HOST_NAME_MAX */
 #ifdef HAVE_ATOMIC
 #include <stdatomic.h>
 #endif

--- a/configure.ac
+++ b/configure.ac
@@ -428,7 +428,8 @@ AC_CONFIG_FILES([Makefile common/Makefile lib/Makefile lib/audit.pc
        auparse/test/Makefile auparse/test/run_auparse_tests.sh
        auparse/test/run_auparselol_test.sh
        auparse/auparse.pc src/Makefile src/libev/Makefile src/test/Makefile
-       docs/Makefile rules/Makefile init.d/Makefile audisp/Makefile
+       docs/Makefile rules/Makefile init.d/Makefile 
+       audisp/Makefile audisp/test/Makefile
        audisp/plugins/Makefile audisp/plugins/af_unix/Makefile
        audisp/plugins/remote/Makefile audisp/plugins/zos-remote/Makefile
        audisp/plugins/syslog/Makefile audisp/plugins/filter/Makefile

--- a/docs/Makefile.am
+++ b/docs/Makefile.am
@@ -44,7 +44,7 @@ audit_syscall_to_name.3 audit_name_to_errno.3\
 audit_fstype_to_name.3 audit_name_to_fstype.3 \
 audit_name_to_action.3 \
 audit_flag_to_name.3 audit_name_to_flag.3 \
-auplugin_fgets.3 \
+auplugin_fgets.3 auplugin.3 \
 auparse_destroy.3 auparse_feed.3 auparse_feed_age_events.3 \
 auparse_feed_has_data.3 auparse_find_field.3 \
 auparse_find_field_next.3 auparse_first_field.3 auparse_first_record.3 \

--- a/docs/auditd-plugins.5
+++ b/docs/auditd-plugins.5
@@ -55,6 +55,17 @@ auditd has an internal queue to hold events for plugins. (See the \fIq_depth\fP 
 
 auditctl --signal cont ; sleep 1 ; cat /var/run/auditd.state
 
+Plugins using
+.BR libauplugin
+can retrieve their own queue metrics with
+.BR auplugin_queue_depth ,
+.BR auplugin_queue_max_depth ,
+and
+.BR auplugin_queue_overflow .
+The
+.BR auplugin_register_stats_callback
+function allows reporting these values from a signal handler.
+
 If auditd's internal queue fills, it cannot dequeue any events from the kernel backlog. If the kernel's backlog fills, it looks at the value of backlog_wait_time to delay all processes that generate an event to see if there is eventually room to add the event. This will likely be noticed as slowing down various processes on the machine. The kernel's audit subsystem can be checked by running:
 
 auditctl -s

--- a/docs/auplugin.3
+++ b/docs/auplugin.3
@@ -4,7 +4,7 @@ auplugin_init, auplugin_stop, auplugin_event_loop, auplugin_event_feed \- plugin
 .SH SYNOPSIS
 .B #include <auplugin.h>
 .sp
-.BI "int auplugin_init(int " inbound_fd ", unsigned " queue_size ");"
+.BI "int auplugin_init(int " inbound_fd ", unsigned " queue_size ", int " q_flags ", const char *" path ");"
 .br
 .B void auplugin_stop(void);
 .br
@@ -19,7 +19,19 @@ parameter specifies the file descriptor that will provide audit
 messages, typically standard input. The
 .I queue_size
 argument controls the maximum number of events that may be queued for
-processing. The library maintains global state for its queue and worker threads. Only one plugin instance is supported, so callers must not invoke auplugin_init() concurrently from multiple threads. The function returns 0 on success or \-1 if initialization fails.
+processing. The
+.I q_flags
+parameter selects in-memory or file-backed storage using the
+.B AUPLUGIN_Q_*
+constants defined in
+.BR auplugin.h .
+If
+.I q_flags
+includes
+.B AUPLUGIN_Q_IN_FILE,
+.I path
+specifies the backing file.
+The library maintains global state for its queue and worker threads. Only one plugin instance is supported, so callers must not invoke auplugin_init() concurrently from multiple threads. The function returns 0 on success or \-1 if initialization fails.
 .PP
 .B auplugin_stop
 signals the framework to terminate. It is normally called from a
@@ -56,6 +68,16 @@ keeps the default behaviour of calling
 .B auparse_feed_age_events
 only. The function returns 0 on success or \-1 if
 libauparse could not be initialized.
+.PP
+Plugins can query queue statistics with
+.BR auplugin_queue_depth ,
+.BR auplugin_queue_max_depth ,
+and
+.BR auplugin_queue_overflow .
+Register a callback with
+.BR auplugin_register_stats_callback ,
+and invoke it using
+.BR auplugin_report_stats .
 .SH SEE ALSO
 .BR auplugin_fgets (3),
 .BR auparse_feed (3)

--- a/docs/auplugin.3
+++ b/docs/auplugin.3
@@ -30,7 +30,8 @@ If
 includes
 .B AUPLUGIN_Q_IN_FILE,
 .I path
-specifies the backing file.
+specifies the backing file. Any events already present in the file are queued
+on startup so plugins resume processing previously unhandled records.
 The library maintains global state for its queue and worker threads. Only one plugin instance is supported, so callers must not invoke auplugin_init() concurrently from multiple threads. The function returns 0 on success or \-1 if initialization fails.
 .PP
 .B auplugin_stop

--- a/docs/auplugin.3
+++ b/docs/auplugin.3
@@ -10,7 +10,7 @@ auplugin_init, auplugin_stop, auplugin_event_loop, auplugin_event_feed \- plugin
 .br
 .BI "void auplugin_event_loop(auplugin_callback_ptr " callback ");"
 .br
-.BI "int auplugin_event_feed(auparse_callback_ptr " callback ");"
+.BI "int auplugin_event_feed(auparse_callback_ptr " callback ", unsigned " timer_interval ", auplugin_timer_callback_ptr " timer_cb ");"
 .SH DESCRIPTION
 .B auplugin_init
 initializes the plugin framework. The
@@ -39,8 +39,13 @@ except that queued events are fed to libauparse. The provided
 .I callback
 must match the
 .B auparse_callback_ptr
-type. The function returns 0 on success or \-1 if libauparse could not
-be initialized.
+type. When
+.I timer_interval
+is non-zero,
+.I timer_cb
+is invoked after each timeout and
+.B auparse_feed_age_events
+is called to flush any aged events. The function returns 0 on success or \-1 if libauparse could not be initialized.
 .SH SEE ALSO
 .BR auplugin_fgets (3),
 .BR auparse_feed (3)

--- a/docs/auplugin.3
+++ b/docs/auplugin.3
@@ -1,0 +1,49 @@
+.TH "AUPLUGIN" "3" "June 2025" "Red Hat" "Linux Audit API"
+.SH NAME
+auplugin_init, auplugin_stop, auplugin_event_loop, auplugin_event_feed \- plugin event processing helpers
+.SH SYNOPSIS
+.B #include <auplugin.h>
+.sp
+.BI "int auplugin_init(int " inbound_fd ", unsigned " queue_size ");"
+.br
+.B void auplugin_stop(void);
+.br
+.BI "void auplugin_event_loop(auplugin_callback_ptr " callback ");"
+.br
+.BI "int auplugin_event_feed(auparse_callback_ptr " callback ");"
+.SH DESCRIPTION
+.B auplugin_init
+initializes the plugin framework. The
+.I inbound_fd
+parameter specifies the file descriptor that will provide audit
+messages, typically standard input. The
+.I queue_size
+argument controls the maximum number of events that may be queued for
+processing. The function returns 0 on success or \-1 if initialization
+fails.
+.PP
+.B auplugin_stop
+signals the framework to terminate. It is normally called from a
+SIGTERM handler or other shutdown logic.
+.PP
+.B auplugin_event_loop
+starts a worker thread to deliver queued events to the supplied
+.I callback
+function one record at a time. The function blocks in the caller until
+.B auplugin_stop
+is invoked.
+.PP
+.B auplugin_event_feed
+behaves like
+.BR auplugin_event_loop ,
+except that queued events are fed to libauparse. The provided
+.I callback
+must match the
+.B auparse_callback_ptr
+type. The function returns 0 on success or \-1 if libauparse could not
+be initialized.
+.SH SEE ALSO
+.BR auplugin_fgets (3),
+.BR auparse_feed (3)
+.SH AUTHOR
+Steve Grubb

--- a/docs/auplugin.3
+++ b/docs/auplugin.3
@@ -39,13 +39,23 @@ except that queued events are fed to libauparse. The provided
 .I callback
 must match the
 .B auparse_callback_ptr
-type. When
+type. The
 .I timer_interval
-is non-zero,
-.I timer_cb
-is invoked after each timeout and
+argument specifies how many seconds the worker thread will wait for new
+records. A value of 0 disables the timer logic. When the interval elapses,
 .B auparse_feed_age_events
-is called to flush any aged events. The function returns 0 on success or \-1 if libauparse could not be initialized.
+is called to flush aged events. If
+.I timer_cb
+is not
+.B NULL,
+it is invoked with the interval before the flush. Passing a
+.I timer_cb
+of
+.B NULL
+keeps the default behaviour of calling
+.B auparse_feed_age_events
+only. The function returns 0 on success or \-1 if
+libauparse could not be initialized.
 .SH SEE ALSO
 .BR auplugin_fgets (3),
 .BR auparse_feed (3)

--- a/docs/auplugin.3
+++ b/docs/auplugin.3
@@ -19,8 +19,7 @@ parameter specifies the file descriptor that will provide audit
 messages, typically standard input. The
 .I queue_size
 argument controls the maximum number of events that may be queued for
-processing. The function returns 0 on success or \-1 if initialization
-fails.
+processing. The library maintains global state for its queue and worker threads. Only one plugin instance is supported, so callers must not invoke auplugin_init() concurrently from multiple threads. The function returns 0 on success or \-1 if initialization fails.
 .PP
 .B auplugin_stop
 signals the framework to terminate. It is normally called from a

--- a/src/auditd-event.c
+++ b/src/auditd-event.c
@@ -33,7 +33,6 @@
 #include <time.h>
 #include <sys/time.h>
 #include <sys/vfs.h>
-#include <limits.h>     /* POSIX_HOST_NAME_MAX */
 #include <ctype.h>	/* toupper */
 #include <libgen.h>	/* dirname */
 #include "auditd-event.h"


### PR DESCRIPTION
Auplugin is intended to provide scaffolding most plugins need. It creates a worker thread, takes over main and places a lockless queue in between. This allows  plugins to adhere to best practices with minimal effort.

This is still a work in progess, but is functional. Merging now to avoid future conflicts as work lands in master.