### PR TITLE
fix build with musl

### DIFF
--- a/auparse/auparse.h
+++ b/auparse/auparse.h
@@ -31,6 +31,8 @@
 #endif
 #ifndef __attr_dealloc
 # define __attr_dealloc(dealloc, argno)
+#endif
+#ifndef __attr_dealloc_free
 # define __attr_dealloc_free
 #endif
 #ifndef __attribute_malloc__

--- a/lib/audit_logging.h
+++ b/lib/audit_logging.h
@@ -25,6 +25,7 @@
 
 // Next include is to pick up the function attribute macros
 #include <features.h>
+#include <sys/types.h>
 #include <audit-records.h>
 
 #ifdef __cplusplus

--- a/lib/audit_logging.h
+++ b/lib/audit_logging.h
@@ -40,6 +40,8 @@ extern "C" {
 #endif
 #ifndef __attr_dealloc
 # define __attr_dealloc(dealloc, argno)
+#endif
+#ifndef __attr_dealloc_free
 # define __attr_dealloc_free
 #endif
 // Warn unused result

--- a/lib/libaudit.h
+++ b/lib/libaudit.h
@@ -43,6 +43,8 @@
 // malloc and free assignments
 #ifndef __attr_dealloc
 # define __attr_dealloc(dealloc, argno)
+#endif
+#ifndef __attr_dealloc_free
 # define __attr_dealloc_free
 #endif
 #ifndef __attribute_malloc__


### PR DESCRIPTION
`sys/types.h` is indirectly included with `glibc`, but needs to be specified explicitly on musl.

~~The symbol collisions on `__attr_dealloc_free` require including auparse first for some reason.~~
Not a symbol collision, rather some `#define`s don't actually define `__attr_dealloc_free` causing the `#ifndef` to skip over `__attr_dealloc_free`, which is then all kinds of broken.

closes #475