### PR TITLE
aureport/ausearch: check for non-input stdin pipes

### DIFF
--- a/audisp/plugins/remote/audisp-remote.c
+++ b/audisp/plugins/remote/audisp-remote.c
@@ -199,17 +199,6 @@ static int sync_error_handler (const char *why)
 	return 0;
 }
 
-static int is_pipe(int fd)
-{
-	struct stat st;
-
-	if (fstat(fd, &st) == 0) {
-		if (S_ISFIFO(st.st_mode))
-			return 1;
-	}
-	return 0;
-}
-
 static void change_runlevel(const char *level)
 {
 	char *argv[3];

--- a/common/common.h
+++ b/common/common.h
@@ -87,6 +87,9 @@ void wall_message(const char *fmt, ...)
 	;
 #endif
 
+int is_pipe(int fd);
+int check_stdin_data(void);
+
 AUDIT_HIDDEN_END
 #endif
 

--- a/src/ausearch-common.h
+++ b/src/ausearch-common.h
@@ -30,6 +30,7 @@
 #include <time.h>
 #include "ausearch-string.h"
 #include "auparse-defs.h"
+#include "common.h"
 
 /*
  * MAX_EVENT_DELTA_SECS is the maximum number of seconds it would take for


### PR DESCRIPTION
Calling aureport or ausearch on a remote host e.g.:

  # ssh host aureport

will make aureport hang on read() because stdin is seen as a pipe (from SSH).  This can be worked around with "ssh -t", but the aforementioned behaviour is not expected anyway.

Fix this by checking if stdin is a pipe, and, if so, poll it to check for available data to read, which will return false for the reproducer.

Following examples now works, or continue to work, successfully:

  # aureport
  # cat audit.log | aureport
  # ssh host aureport
  # ssh host "cat audit.log | aureport"
  # cat audit.log | ssh host aureport