### PR TITLE
Fix possible deference crash in auparse_interp_adjust_type()

### DIFF
--- a/auparse/interpret.c
+++ b/auparse/interpret.c
@@ -3277,7 +3277,11 @@ const char *do_interpret(auparse_state_t *au, rnode *r)
  */
 int auparse_interp_adjust_type(int rtype, const char *name, const char *val)
 {
-	int type;
+	int type = AUPARSE_TYPE_UNCLASSIFIED;
+
+	if (!name || !val) {
+		return type;
+	}
 
 	/* This set of statements overrides or corrects the detection.
 	 * In almost all cases its a double use of a field. */

--- a/auparse/nvlist.c
+++ b/auparse/nvlist.c
@@ -60,6 +60,7 @@ int nvlist_append(nvlist *l, const nvnode *node)
 {
 	if ((node->name == NULL) ||
 		(node->val == NULL))
+		return 1;
 
 	if (l->array == NULL)
 		alloc_array(l);

--- a/auparse/nvlist.c
+++ b/auparse/nvlist.c
@@ -58,8 +58,8 @@ nvnode *nvlist_next(nvlist *l)
 // 0 on success and 1 on error
 int nvlist_append(nvlist *l, const nvnode *node)
 {
-	if (node->name == NULL)
-		return 1;
+	if ((node->name == NULL) ||
+		(node->val == NULL))
 
 	if (l->array == NULL)
 		alloc_array(l);


### PR DESCRIPTION
Hi, we are fuzzing auparse code and we found a potential segfault in `auparse_interp_adjust_type()`.

To reproduce that, used code:
```
#include <stdio.h>
#include <stdlib.h>
#include <unistd.h>
#include <string.h>
#include <locale.h>
#include <errno.h>
#include "libaudit.h"
#include "auparse.h"

unsigned int walked_fields = 0;
#define FIELDS_EXPECTED 403

static void walk_test(auparse_state_t *au)
{
    int event_cnt = 1, record_cnt;

    do {
        if (auparse_first_record(au) <= 0) {
            printf("Error getting first record (%s)\n",
                   strerror(errno));
            exit(1);
        }
        printf("event %d has %u records\n", event_cnt,
               auparse_get_num_records(au));
        record_cnt = 1;
        do {
            printf("    record %d of type %d(%s) has %u fields\n",
                   record_cnt,
                   auparse_get_type(au),
                   audit_msg_type_to_name(auparse_get_type(au)),
                   auparse_get_num_fields(au));
            printf("    line=%u file=%s\n",
                   auparse_get_line_number(au),
                   auparse_get_filename(au) ?
                   auparse_get_filename(au) : "None");
            const au_event_t *e = auparse_get_timestamp(au);
            if (e == NULL) {
                printf("Error getting timestamp - aborting\n");
                exit(1);
            }
            printf("    event time: %u.%u:%lu, host=%s\n",
                   (unsigned)e->sec,
                   e->milli, e->serial, e->host ? e->host : "?");
            auparse_first_field(au);
            do {
                printf("        %s=%s (%s)\n",
                       auparse_get_field_name(au),
                       auparse_get_field_str(au),
                       auparse_interpret_field(au));
                walked_fields++;
            } while (auparse_next_field(au) > 0);
            printf("\n");
            record_cnt++;
        } while (auparse_next_record(au) > 0);
        event_cnt++;
    } while (auparse_next_event(au) > 0);
}

void light_test(auparse_state_t *au)
{
    int record_cnt;

    do {
        if (auparse_first_record(au) <= 0) {
            puts("Error getting first record");
            exit(1);
        }
        printf("event has %u records\n", auparse_get_num_records(au));
        record_cnt = 1;
        do {
            printf("    record %d of type %d(%s) has %u fields\n",
                   record_cnt,
                   auparse_get_type(au),
                   audit_msg_type_to_name(auparse_get_type(au)),
                   auparse_get_num_fields(au));
            printf("    line=%u file=%s\n",
                   auparse_get_line_number(au),
                   auparse_get_filename(au) ?
                   auparse_get_filename(au) : "None");
            const au_event_t *e = auparse_get_timestamp(au);
            if (e == NULL) {
                printf("Error getting timestamp - aborting\n");
                exit(1);
            }
            printf("    event time: %u.%u:%lu, host=%s\n",
                   (unsigned)e->sec,
                   e->milli, e->serial,
                   e->host ? e->host : "?");
            printf("\n");
            record_cnt++;
        } while (auparse_next_record(au) > 0);

    } while (auparse_next_event(au) > 0);
}

void simple_search(ausource_t source, austop_t where, const char *input)
{
    auparse_state_t *au;
    const char *val = "848";

    au = auparse_init(source, input);
    if (au == NULL) {
        printf("auparse_init error - %s\n", strerror(errno));
        exit(1);
    }
    if (ausearch_add_item(au, "auid", "=", val, AUSEARCH_RULE_CLEAR)) {
        printf("ausearch_add_item error - %s\n", strerror(errno));
        exit(1);
    }
    if (ausearch_set_stop(au, where)) {
        printf("ausearch_set_stop error - %s\n", strerror(errno));
        exit(1);
    }
    if (ausearch_next_event(au) <= 0)
        printf("Error searching for auid - %s\n", strerror(errno));
    else
        printf("Found %s = %s\n", auparse_get_field_name(au),
               auparse_get_field_str(au));
    auparse_destroy(au);
}

void compound_search(ausearch_rule_t how, const char *input)
{
    auparse_state_t *au;

    au = auparse_init(AUSOURCE_FILE, input);
    if (au == NULL) {
        printf("auparse_init error - %s\n", strerror(errno));
        exit(1);
    }
    if (how == AUSEARCH_RULE_AND) {
        if (ausearch_add_item(au, "uid", "=", "0",
                              AUSEARCH_RULE_CLEAR)) {
            printf("ausearch_add_item 1 error - %s\n",
                   strerror(errno));
            exit(1);
        }
        if (ausearch_add_item(au, "pid", "=", "13015", how)) {
            printf("ausearch_add_item 2 error - %s\n",
                   strerror(errno));
            exit(1);
        }
        if (ausearch_add_item(au, "type", "=", "USER_START", how)) {
            printf("ausearch_add_item 3 error - %s\n",
                   strerror(errno));
            exit(1);
        }
    } else {
        if (ausearch_add_item(au, "auid", "=", "42",
                              AUSEARCH_RULE_CLEAR)) {
            printf("ausearch_add_item 4 error - %s\n",
                   strerror(errno));
            exit(1);
        }
        if (ausearch_add_item(au, "auid", "=", "0", how)) {
            printf("ausearch_add_item 5 error - %s\n",
                   strerror(errno));
            exit(1);
        }
        if (ausearch_add_item(au, "auid", "=", "500", how)) {
            printf("ausearch_add_item 6 error - %s\n",
                   strerror(errno));
            exit(1);
        }
    }
    if (ausearch_set_stop(au, AUSEARCH_STOP_FIELD)) {
        printf("ausearch_set_stop error - %s\n", strerror(errno));
        exit(1);
    }
    if (ausearch_next_event(au) <= 0)
        printf("Error searching for auid - %s\n", strerror(errno));
    else
        printf("Found %s = %s\n", auparse_get_field_name(au),
               auparse_get_field_str(au));
    auparse_destroy(au);
}

void regex_search(const char *expr, const char *input)
{
    auparse_state_t *au;
    int rc;

    au = auparse_init(AUSOURCE_FILE, input);
    if (au == NULL) {
        printf("auparse_init error - %s\n", strerror(errno));
        exit(1);
    }
    if (ausearch_add_regex(au, expr)) {
        printf("ausearch_add_regex error - %s\n", strerror(errno));
        exit(1);
    }
    if (ausearch_set_stop(au, AUSEARCH_STOP_RECORD)) {
        printf("ausearch_set_stop error - %s\n", strerror(errno));
        exit(1);
    }
    rc = ausearch_next_event(au);
    if (rc < 0)
        printf("Error searching for %s - %s\n", expr, strerror(errno));
    else if (rc == 0)
        printf("Not found\n");
    else
        printf("Found %s = %s\n", auparse_get_field_name(au),
               auparse_get_field_str(au));
    auparse_destroy(au);
}

int main(int argc, char *argv[])
{
    if (argc < 2) {
        fprintf(stderr, "Usage: %s <audit_log_file>\n", argv[0]);
        return 1;
    }

    setlocale(LC_ALL, "");
    auparse_state_t *au;

    // Initialize auparse with the input file
    au = auparse_init(AUSOURCE_FILE, argv[1]);
    if (au == NULL) {
        printf("Error - %s\n", strerror(errno));
        return 1;
    }

    printf("Starting walk test on file: %s\n", argv[1]);
    walk_test(au);
    auparse_destroy(au);

    printf("Starting light test on file: %s\n", argv[1]);
    au = auparse_init(AUSOURCE_FILE, argv[1]);
    if (au == NULL) {
        printf("Error - %s\n", strerror(errno));
        return 1;
    }
    light_test(au);
    auparse_destroy(au);

    printf("Starting simple search tests on file: %s\n", argv[1]);
    simple_search(AUSOURCE_FILE, AUSEARCH_STOP_FIELD, argv[1]);
    simple_search(AUSOURCE_FILE, AUSEARCH_STOP_RECORD, argv[1]);
    simple_search(AUSOURCE_FILE, AUSEARCH_STOP_EVENT, argv[1]);

    printf("Starting compound search tests on file: %s\n", argv[1]);
    compound_search(AUSEARCH_RULE_AND, argv[1]);
    compound_search(AUSEARCH_RULE_OR, argv[1]);

    printf("Starting regex search tests on file: %s\n", argv[1]);
    regex_search("1143146623", argv[1]);
    regex_search("11431466.*146", argv[1]);

    if (walked_fields != FIELDS_EXPECTED) {
        printf("Error: %i fields expected, but %i read!\n",
               FIELDS_EXPECTED, walked_fields);
    } else {
        printf("All tests completed successfully.\n");
    }

    return 0;
}
```

Building binary:
```
gcc -o fuzz fuzz-auparse.c -lauparse -laudit
```

To reproduce build please use log attached:
```
./fuzz <path-to-log>
```

Those caused SIGSERV:
```
    "    #0 0x5555555a6e2e in strlen (/home/developer/fuzzing/auparse/fuzz_auparse+0x52e2e) (BuildId: 2f8f35048af810d2e6b2f995879558a6a6a42b95)",
    "    #1 0x5555556ab15e in auparse_do_interpretation /home/developer/src/audit-3.1.2/auparse/interpret.c:3403:22",
    "    #2 0x5555556a8568 in do_interpret /home/developer/src/audit-3.1.2/auparse/interpret.c:3155:8",
    "    #3 0x5555556cd46c in nvlist_interp_cur_val /home/developer/src/audit-3.1.2/auparse/nvlist.c:156:9",
    "    #4 0x5555556793ba in auparse_interpret_field /home/developer/src/audit-3.1.2/auparse/auparse.c:2147:11",
    "    #5 0x55555566a88b in walk_test /home/developer/fuzzing/auparse/fuzz_auparse.c:49:24",
    "    #6 0x555555669fb3 in main /home/developer/fuzzing/auparse/fuzz_auparse.c:225:5",
    "    #7 0x7ffff7c2a1c9 in __libc_start_call_main csu/../sysdeps/nptl/libc_start_call_main.h:58:16",
    "    #8 0x7ffff7c2a28a in __libc_start_main csu/../csu/libc-start.c:360:3",
    "    #9 0x55555558f5a4 in _start (/home/developer/fuzzing/auparse/fuzz_auparse+0x3b5a4) (BuildId: 2f8f35048af810d2e6b2f995879558a6a6a42b95)",
```

Patch added some checks to fix SEGFAULT on incorrect input variables.

 Found by Linux Verification Center (linuxtesting.org) with SVACE.
[audit.log](https://github.com/user-attachments/files/21411941/audit.log)
