### PR TITLE
libaudit: fix includes for musl once again

### DIFF
--- a/lib/libaudit.c
+++ b/lib/libaudit.c
@@ -40,6 +40,7 @@
 #include <limits.h>	/* for PATH_MAX */
 #include <sys/types.h>
 #include <sys/socket.h> /* AF_MAX */
+#include <libgen.h>	/* For basename */
 #ifdef HAVE_LIBCAP_NG
 #include <cap-ng.h>
 #endif


### PR DESCRIPTION
with glibc, `basename` is provided by string.h. However, musl exposes `basename` only in `libgen.h`.

In glibc `libgen.h`, there is this warning:
```C
/* Return final component of PATH.

   This is the weird XPG version of this function.  It sometimes will
   modify its argument.  Therefore we normally use the GNU version (in
   <string.h>) and only if this header is included make the XPG
   version available under the real name.  */
extern char *__xpg_basename (char *__path) __THROW;
#define basename	__xpg_basename
```

This makes that version of `basename` probably a bad default. As far as i can tell, this is not an issue on musl. Hence, only fall back to `libgen.h` if `basename` is not yet defined.