### PR TITLE
auditd.service: set LogsDirectory and RuntimeDirectory, remove tmpfiles dependency

### DIFF
--- a/audit.spec
+++ b/audit.spec
@@ -222,7 +222,6 @@ fi
 %attr(755,root,root) %{_bindir}/aulast
 %attr(755,root,root) %{_bindir}/aulastlog
 %attr(755,root,root) %{_bindir}/ausyscall
-%attr(640,root,root) %{_tmpfilesdir}/audit.conf
 %attr(644,root,root) %{_unitdir}/auditd.service
 %attr(750,root,root) %dir %{_libexecdir}/initscripts/legacy-actions/auditd
 %attr(750,root,root) %{_libexecdir}/initscripts/legacy-actions/auditd/condrestart

--- a/init.d/Makefile.am
+++ b/init.d/Makefile.am
@@ -24,7 +24,6 @@
 CONFIG_CLEAN_FILES = *.rej *.orig
 CLEANFILES = $(BUILT_SOURCES)
 EXTRA_DIST = auditd.service.in audit-rules.service.in  auditd.conf auditd.cron \
-	audit-tmpfiles.conf \
 	libaudit.conf auditd.condrestart \
 	auditd.reload auditd.restart auditd.resume \
 	auditd.rotate auditd.state auditd.stop audit-rules.service \
@@ -48,8 +47,6 @@ BUILT_SOURCES = auditd.service audit-rules.service
 
 install-data-hook:
 	$(INSTALL_DATA) -D -m 640 ${srcdir}/${libconfig} ${DESTDIR}${sysconfdir}
-	mkdir -p ${DESTDIR}$(prefix)/lib/tmpfiles.d/
-	$(INSTALL_DATA) -m 640 ${srcdir}/audit-tmpfiles.conf ${DESTDIR}$(prefix)/lib/tmpfiles.d/audit.conf
 
 install-exec-hook:
 	mkdir -p ${DESTDIR}${initdir}
@@ -81,5 +78,4 @@ uninstall-hook:
 	rm ${DESTDIR}${legacydir}/stop
 	rm ${DESTDIR}${legacydir}/restart
 	rm ${DESTDIR}${legacydir}/condrestart
-	rm ${DESTDIR}$(prefix)/lib/tmpfiles.d/audit.conf
 	rm ${DESTDIR}${sysconfdir}/bash_completion.d/audit.bash_completion

--- a/init.d/audit-rules.service.in
+++ b/init.d/audit-rules.service.in
@@ -5,7 +5,7 @@ ConditionKernelCommandLine=!audit=off
 DefaultDependencies=no
 # We need the local file system for the rules. Augenrules uses /tmp while
 # constructing rules, so we have to wait for that to be available, too.
-After=local-fs.target systemd-tmpfiles-setup.service
+After=local-fs.target
 
 Documentation=man:auditctl(8) https://github.com/linux-audit/audit-documentation
 

--- a/init.d/audit-tmpfiles.conf
+++ b/init.d/audit-tmpfiles.conf
@@ -1,1 +1,0 @@
-d /var/log/audit 0700 root root - -

--- a/init.d/auditd.service.in
+++ b/init.d/auditd.service.in
@@ -19,8 +19,8 @@ Wants=audit-rules.service
 ## If using remote logging, ensure that the systemd-update-utmp.service file
 ## is updated to remove the After=auditd.service directive to prevent a
 ## boot-time ordering cycle.
-After=local-fs.target systemd-tmpfiles-setup.service
-#After=network-online.target local-fs.target systemd-tmpfiles-setup.service
+After=local-fs.target
+#After=network-online.target local-fs.target
 Before=sysinit.target shutdown.target audit-rules.service
 #Before=shutdown.target
 Conflicts=shutdown.target


### PR DESCRIPTION
setting LogsDirectory and RuntimeDirectory ensures systemd will create these directories ahead of starting the auditd service. It also ensures the auditd service has write permissions, even if someone might add additional hardening options to the systemd service in the future. As a result, there is just no more need for the tmpfiles rules.