### PR TITLE
Fix NEGATIVE_CODE_ERROR in libev ev.c sigfdcb

### DIFF
--- a/src/libev/ev.c
+++ b/src/libev/ev.c
@@ -2965,6 +2965,9 @@ sigfdcb (EV_P_ ev_io *iow, int revents)
     {
       ssize_t res = read (sigfd, si, sizeof (si));
 
+      if (res < 0)
+        break;
+
       /* not ISO-C, as res might be -1, but works with SuS */
       for (sip = si; (char *)sip < (char *)si + res; ++sip)
         ev_feed_signal_event (EV_A_ sip->ssi_signo);


### PR DESCRIPTION
Add check for negative return value from read() before using it in pointer arithmetic. This prevents undefined behavior when read() returns -1 on error.

Similar fix was applied to infy_cb in commit 87296f7f ("Fix a libev static analysis warning").

Svace report (for audit-userspace v3.0.8):
  Variable 'res', which might receive a negative value at ev.c:2966
  by calling function 'read', is used without checking at ev.c:2969.
  (CWE129, CWE394, CWE606)
