### PR TITLE
Fix NO_CAST.INTEGER_OVERFLOW in libev ev.c array_nextsize

### DIFF
--- a/src/libev/ev.c
+++ b/src/libev/ev.c
@@ -2256,10 +2256,10 @@ array_nextsize (int elem, int cur, int cnt)
   while (cnt > ncur);
 
   /* if size is large, round to MALLOC_ROUND - 4 * longs to accommodate malloc overhead */
-  if (elem * ncur > MALLOC_ROUND - sizeof (void *) * 4)
+  if ((size_t)elem * ncur > MALLOC_ROUND - sizeof (void *) * 4)
     {
       ncur *= elem;
-      ncur = (ncur + elem + (MALLOC_ROUND - 1) + sizeof (void *) * 4) & ~(MALLOC_ROUND - 1);
+      ncur = ((size_t)ncur + elem + (MALLOC_ROUND - 1) + sizeof (void *) * 4) & ~(MALLOC_ROUND - 1);
       ncur = ncur - sizeof (void *) * 4;
       ncur /= elem;
     }
@@ -2272,7 +2272,7 @@ static void *
 array_realloc (int elem, void *base, int *cur, int cnt)
 {
   *cur = array_nextsize (elem, *cur, cnt);
-  return ev_realloc (base, elem * *cur);
+  return ev_realloc (base, (size_t)elem * *cur);
 }
 
 #define array_needsize_noinit(base,offset,count)


### PR DESCRIPTION
Add explicit casts to size_t in arithmetic expressions to prevent potential integer overflow when calculating array sizes.

Overflows are not very realistic, but improve code robustness and make analyzers happy.

Svace reports:
  1) The value of 'elem * ncur' may overflow (ev.c:2259)
  2) The value of 'ncur + elem + (MALLOC_ROUND - 1)' may overflow (ev.c:2262)
  3) The value of 'elem * *cur' may overflow (ev.c:2275)
  (CWE190, CWE197)
