### PR TITLE
zos-remote-config: include libgen.h for basename(3)

### DIFF
--- a/audisp/plugins/zos-remote/zos-remote-config.c
+++ b/audisp/plugins/zos-remote/zos-remote-config.c
@@ -32,6 +32,7 @@
 #include <ctype.h>
 #include <unistd.h>
 #include <stdlib.h>
+#include <libgen.h> /* for basename(3) */
 #include "zos-remote-log.h"
 
 /* Local prototypes */


### PR DESCRIPTION
POSIX stipulates that basename(3) is provided by libgen.h[1]. The musl libc, since 1.2.5, has stopped providing basename(3) in string.h[2]. As such, include libgen.h for our usage of basename(3).

A similar patch is currently carried downstream by Gentoo[3][4].

[1] https://pubs.opengroup.org/onlinepubs/9799919799/
[2] https://git.musl-libc.org/cgit/musl/commit/?id=725e17ed6dff4d0cd22487bb64470881e86a92e7
[3] https://codeberg.org/gentoo/gentoo/src/commit/2ac58d82e4db15c305a039841e81a07d918529e5/sys-process/audit/files/audit-4.0.1-musl-basename.patch
[4] https://codeberg.org/gentoo/gentoo/commit/d1f53d5bae5657db01f6aac127f352e21ccf14eb