### PR TITLE
autls: add Phase 0 TLS policy, ACL, and hardening on top of transport layer

### DIFF
--- a/audisp/plugins/remote/audisp-remote.c
+++ b/audisp/plugins/remote/audisp-remote.c
@@ -249,8 +249,10 @@ static void user2_handler( int sig )
  */
 static void child_handler(int sig)
 {
+	int saved_errno = errno;
 	while (waitpid(-1, NULL, WNOHANG) > 0)
 		; /* empty */
+	errno = saved_errno;
 }
 
 /*
@@ -1220,6 +1222,7 @@ static int init_tls_context(void)
 	}
 
 	SSL_CTX_set_options(tls_ctx, SSL_OP_NO_COMPRESSION);
+	SSL_CTX_set_mode(tls_ctx, SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
 
 	/* Disable session resumption -- force fresh PQC key exchange */
 	SSL_CTX_set_session_cache_mode(tls_ctx, SSL_SESS_CACHE_OFF);

--- a/audisp/plugins/remote/audisp-remote.c
+++ b/audisp/plugins/remote/audisp-remote.c
@@ -1275,18 +1275,28 @@ static int init_tls_context(void)
 
 		SSL_CTX_set_psk_use_session_callback(tls_ctx,
 						tls_psk_use_session_cb);
-		{
-			const char *id = config.tls_psk_identity ?
-				config.tls_psk_identity : "audit-client";
-			if (strlen(id) >= sizeof(psk_identity_buf)) {
-				syslog(LOG_ERR,
-					"PSK identity too long (max %zu bytes)",
-					sizeof(psk_identity_buf) - 1);
-				goto err;
-			}
-			snprintf(psk_identity_buf,
-				sizeof(psk_identity_buf), "%s", id);
+		if (config.tls_psk_identity == NULL) {
+			syslog(LOG_ERR,
+				"tls_psk_identity is required");
+			goto err;
 		}
+		if (autls_validate_psk_identity(
+				(const unsigned char *)
+				config.tls_psk_identity,
+				strlen(config.tls_psk_identity),
+				syslog) != 0)
+			goto err;
+		if (strlen(config.tls_psk_identity) >=
+		    sizeof(psk_identity_buf)) {
+			syslog(LOG_ERR,
+				"PSK identity too long "
+				"(max %zu bytes)",
+				sizeof(psk_identity_buf) - 1);
+			goto err;
+		}
+		snprintf(psk_identity_buf,
+			sizeof(psk_identity_buf), "%s",
+			config.tls_psk_identity);
 	}
 
 	/* Certificate mode */

--- a/audisp/plugins/remote/audisp-remote.c
+++ b/audisp/plugins/remote/audisp-remote.c
@@ -548,10 +548,11 @@ int main(int argc, char *argv[])
 	sigaction(SIGUSR1, &sa, NULL);
 	sa.sa_handler = user2_handler;
 	sigaction(SIGUSR2, &sa, NULL);
+	sa.sa_flags = SA_RESTART;
 	sa.sa_handler = child_handler;
 	sigaction(SIGCHLD, &sa, NULL);
-	sa.sa_sigaction = term_handler;
 	sa.sa_flags = SA_SIGINFO;
+	sa.sa_sigaction = term_handler;
 	sigaction(SIGTERM, &sa, NULL);
 	if (load_config(&config, CONFIG_FILE))
 		return 6;

--- a/audisp/plugins/remote/audisp-remote.c
+++ b/audisp/plugins/remote/audisp-remote.c
@@ -67,6 +67,13 @@
 #define CONFIG_FILE "/etc/audit/audisp-remote.conf"
 #define BUF_SIZE 32
 
+#ifdef HAVE_TLS
+_Static_assert(AUTLS_PROFILE_STANDARD == TLS_PROFILE_STANDARD &&
+	       AUTLS_PROFILE_FIPS == TLS_PROFILE_FIPS &&
+	       AUTLS_PROFILE_PQC == TLS_PROFILE_PQC,
+	       "autls profile constants out of sync with config enums");
+#endif
+
 /* Error types */
 #define ET_SUCCESS	 0
 #define ET_PERMANENT	-1
@@ -1183,6 +1190,8 @@ static int tls_psk_use_session_cb(SSL *ssl, const EVP_MD *md,
  * groups, and either PSK or certificate authentication.
  * Returns 0 on success, -1 on error.
  */
+static int tls_error_cb(const char *str, size_t len, void *u);
+
 static int init_tls_context(void)
 {
 	const char *cipher_suites;
@@ -1212,33 +1221,49 @@ static int init_tls_context(void)
 	SSL_CTX_set_session_cache_mode(tls_ctx, SSL_SESS_CACHE_OFF);
 	SSL_CTX_set_options(tls_ctx, SSL_OP_NO_TICKET);
 
-	/* Configure cipher suites */
+	/* Configure cipher suites from profile or override */
 	cipher_suites = config.tls_cipher_suites ?
 		config.tls_cipher_suites :
-		"TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256";
-	if (!SSL_CTX_set_ciphersuites(tls_ctx, cipher_suites)) {
-		syslog(LOG_ERR, "Unable to set TLS cipher suites");
-		goto err;
-	}
-
-	/* Configure key exchange groups (PQC hybrid first) */
-	key_exchange = config.tls_key_exchange ?
-		config.tls_key_exchange : "X25519MLKEM768:X25519";
-	if (!SSL_CTX_set1_groups_list(tls_ctx, key_exchange)) {
-		ERR_clear_error();
-		if (config.tls_require_pqc || config.tls_key_exchange) {
-			syslog(LOG_ERR,
-				"Unable to set key exchange groups '%s'",
-				key_exchange);
+		autls_profile_ciphers(config.tls_crypto_profile);
+	if (cipher_suites) {
+		if (!SSL_CTX_set_ciphersuites(tls_ctx, cipher_suites)) {
+			syslog(LOG_ERR, "Unable to set TLS cipher suites");
 			goto err;
 		}
+	}
+
+	if (config.tls_crypto_profile == TLS_PROFILE_PQC &&
+	    config.tls_key_exchange)
 		syslog(LOG_WARNING,
-			"PQC key exchange groups not available, "
-			"falling back to X25519");
-		if (!SSL_CTX_set1_groups_list(tls_ctx, "X25519")) {
-			syslog(LOG_ERR,
-				"Unable to set any key exchange groups");
-			goto err;
+			"tls_key_exchange override set with PQC "
+			"profile; connections will fail if override "
+			"excludes PQC groups");
+
+	/* Configure key exchange groups from profile or override */
+	key_exchange = config.tls_key_exchange ?
+		config.tls_key_exchange :
+		autls_profile_groups(config.tls_crypto_profile);
+	if (key_exchange) {
+		if (!SSL_CTX_set1_groups_list(tls_ctx, key_exchange)) {
+			ERR_print_errors_cb(tls_error_cb, NULL);
+			if (config.tls_crypto_profile !=
+			    TLS_PROFILE_STANDARD ||
+			    config.tls_key_exchange) {
+				syslog(LOG_ERR,
+					"Unable to set key exchange "
+					"groups '%s'", key_exchange);
+				goto err;
+			}
+			syslog(LOG_WARNING,
+				"PQC key exchange groups not "
+				"available, falling back to X25519");
+			if (!SSL_CTX_set1_groups_list(tls_ctx,
+						      "X25519")) {
+				syslog(LOG_ERR,
+					"Unable to set any key "
+					"exchange groups");
+				goto err;
+			}
 		}
 	}
 
@@ -1317,6 +1342,7 @@ static int init_tls_context(void)
 
 	return 0;
 err:
+	ERR_print_errors_cb(tls_error_cb, NULL);
 	if (psk_key) {
 		OPENSSL_cleanse(psk_key, psk_key_len);
 		OPENSSL_free(psk_key);
@@ -1429,7 +1455,8 @@ static int tls_connect(void)
 		config.remote_server, SSL_get_cipher(tls_ssl),
 		kex_name ? kex_name : "unknown");
 
-	if (config.tls_require_pqc && !autls_is_pqc_group(kex_name)) {
+	if (config.tls_crypto_profile == TLS_PROFILE_PQC &&
+	    !autls_is_pqc_group(kex_name)) {
 		syslog(LOG_ERR,
 			"PQC key exchange required but negotiated "
 			"group '%s' is not PQC",

--- a/audisp/plugins/remote/audisp-remote.c
+++ b/audisp/plugins/remote/audisp-remote.c
@@ -1166,12 +1166,15 @@ static int tls_psk_use_session_cb(SSL *ssl, const EVP_MD *md,
 	}
 
 	s = SSL_SESSION_new();
-	if (s == NULL)
+	if (s == NULL) {
+		syslog(LOG_ERR, "TLS PSK: SSL_SESSION_new failed");
 		return 0;
+	}
 
 	if (!SSL_SESSION_set1_master_key(s, psk_key, psk_key_len) ||
 	    !SSL_SESSION_set_cipher(s, cipher) ||
 	    !SSL_SESSION_set_protocol_version(s, TLS1_3_VERSION)) {
+		syslog(LOG_ERR, "TLS PSK: SSL session setup failed");
 		SSL_SESSION_free(s);
 		return 0;
 	}
@@ -1310,17 +1313,9 @@ static int init_tls_context(void)
 	}
 
 	if (config.tls_key_file) {
-		if (autls_validate_key_file(config.tls_key_file,
-				syslog) != 0)
+		if (autls_load_key_file(config.tls_key_file,
+				tls_ctx, syslog) != 0)
 			goto err;
-
-		if (SSL_CTX_use_PrivateKey_file(tls_ctx,
-				config.tls_key_file,
-				SSL_FILETYPE_PEM) != 1) {
-			syslog(LOG_ERR, "Unable to load TLS private key %s",
-				config.tls_key_file);
-			goto err;
-		}
 	}
 
 	/* Verify cert and key match */

--- a/audisp/plugins/remote/audisp-remote.conf
+++ b/audisp/plugins/remote/audisp-remote.conf
@@ -32,12 +32,15 @@ startup_failure_action = warn_once_continue
 ##krb5_key_file = /etc/audisp/audisp-remote.key
 
 ## TLS transport options (requires transport = tls)
-## Configure either tls_psk_file or tls_cert_file+tls_key_file
-##tls_cert_file = /etc/audit/tls/client-cert.pem
-##tls_key_file = /etc/audit/tls/client-key.pem
-##tls_ca_file = /etc/audit/tls/ca-cert.pem
+##tls_auth = psk
+##tls_crypto_profile = standard
 ##tls_psk_file = /etc/audit/tls/audit.psk
-##tls_psk_identity = audit-client
+##tls_psk_identity = my-sender-01
+## Advanced overrides:
 ##tls_cipher_suites = TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256
 ##tls_key_exchange = X25519MLKEM768:X25519
 ##tls_require_pqc = no
+## Certificate mode (not supported in this tech preview):
+##tls_cert_file = /etc/audit/tls/client-cert.pem
+##tls_key_file = /etc/audit/tls/client-key.pem
+##tls_ca_file = /etc/audit/tls/ca-cert.pem

--- a/audisp/plugins/remote/audisp-remote.conf.5
+++ b/audisp/plugins/remote/audisp-remote.conf.5
@@ -233,7 +233,9 @@ Path to the CA certificate used to verify the remote server's TLS certificate. W
 Path to a file containing a hex-encoded pre-shared key for TLS-PSK authentication. The key must be at least 32 bytes (64 hex characters) to provide adequate security. Generate a key with: openssl rand \-hex 32. The file must be owned by root and mode 0400. This is the recommended authentication mode for large-scale deployments where PKI is not available.
 .TP
 .I tls_psk_identity
-The identity string sent to the server during TLS-PSK authentication. The default is "audit-client".
+The identity string sent to the server during TLS-PSK authentication. This option is required when
+.I tls_psk_file
+is set. The identity must contain only printable ASCII characters (no spaces or control characters) and must not exceed 255 bytes. There is no default.
 .TP
 .I tls_cipher_suites
 Colon-separated list of TLS 1.3 cipher suites. The default is "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256".

--- a/audisp/plugins/remote/audisp-remote.conf.5
+++ b/audisp/plugins/remote/audisp-remote.conf.5
@@ -229,8 +229,25 @@ Path to the client TLS private key in PEM format. The file must be owned by root
 .I tls_ca_file
 Path to the CA certificate used to verify the remote server's TLS certificate. When set, server certificate verification is enabled using this CA. When not set in certificate mode (not PSK-only), the system CA store is used for server verification. In PSK-only mode without tls_ca_file, server certificate verification is skipped since PSK provides mutual authentication.
 .TP
+.I tls_auth
+The TLS authentication mode. Currently only
+.I psk
+is supported. The default is
+.IR psk .
+.TP
+.I tls_crypto_profile
+Selects the cryptographic profile for TLS. Valid values are
+.IR standard ", " fips ", and " pqc .
+.I standard
+uses robust classical TLS 1.3 PSK with opportunistic PQC hybrid key exchange.
+.I fips
+defers to system crypto policy.
+.I pqc
+requires post-quantum hybrid key exchange. The default is
+.IR standard .
+.TP
 .I tls_psk_file
-Path to a file containing a hex-encoded pre-shared key for TLS-PSK authentication. The key must be at least 32 bytes (64 hex characters) to provide adequate security. Generate a key with: openssl rand \-hex 32. The file must be owned by root and mode 0400. This is the recommended authentication mode for large-scale deployments where PKI is not available.
+Path to a file containing a hex-encoded pre-shared key for TLS-PSK authentication. The key must be at least 32 bytes (64 hex characters). Generate a key with: openssl rand \-hex 32. The file must be owned by root and mode 0400.
 .TP
 .I tls_psk_identity
 The identity string sent to the server during TLS-PSK authentication. This option is required when
@@ -238,20 +255,20 @@ The identity string sent to the server during TLS-PSK authentication. This optio
 is set. The identity must contain only printable ASCII characters (no spaces or control characters) and must not exceed 255 bytes. There is no default.
 .TP
 .I tls_cipher_suites
-Colon-separated list of TLS 1.3 cipher suites. The default is "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256".
+Colon-separated list of TLS 1.3 cipher suites. Overrides the profile default. The default is "TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_256_GCM_SHA384".
 .TP
 .I tls_key_exchange
-Colon-separated list of key exchange groups. The default is "X25519MLKEM768:X25519" which uses post-quantum hybrid key exchange (ML-KEM-768 combined with X25519) as the primary option, falling back to classical X25519 if the server does not support PQC groups. Note that PQC hybrid key exchange increases the TLS ClientHello size by approximately 1120 bytes, which may require updates to network middleboxes performing deep packet inspection.
+Colon-separated list of key exchange groups. Overrides the profile default. PQC hybrid key exchange increases the TLS ClientHello size by approximately 1120 bytes.
 .TP
 .I tls_require_pqc
-If set to
+Compatibility alias for tls_crypto_profile=pqc. If set to
 .IR yes ,
-the client will refuse to connect when post-quantum key exchange groups are not available, and will abort connections where a classical-only group is negotiated, instead of falling back silently. When set to
-.IR no
-(the default), the client will fall back to X25519 if PQC groups are not supported. Note that PSK mode with PQC key exchange provides fully quantum-resistant transport (both confidentiality and authentication). Certificate mode with PQC key exchange provides quantum-resistant confidentiality but relies on classical signatures for authentication until ML-DSA certificates are deployed.
+sets tls_crypto_profile to pqc. If set to
+.IR no ,
+has no effect on tls_crypto_profile. New configurations should use tls_crypto_profile directly.
 
 .SH "NOTES"
-Changes to TLS configuration options (tls_cert_file, tls_key_file, tls_ca_file, tls_psk_file, tls_cipher_suites, tls_key_exchange, tls_require_pqc) require a full daemon restart to take effect. SIGHUP will force a reconnection using the existing TLS context but will not re-read TLS configuration.
+Changes to TLS configuration options (tls_cert_file, tls_key_file, tls_ca_file, tls_psk_file, tls_psk_identity, tls_cipher_suites, tls_key_exchange, tls_require_pqc, tls_auth, tls_crypto_profile) in the configuration file are not re-read on SIGHUP. However, SIGHUP destroys the current TLS context and forces a full reconnection with a new context built from the current (unchanged) configuration. Because the PSK key file is re-read from disk during context creation, rotating the key file contents followed by SIGHUP will activate the new key.
 
 Specifying a local port may make it difficult to restart the audit
 subsystem due to the previous connection being in a TIME_WAIT state,

--- a/audisp/plugins/remote/remote-config.c
+++ b/audisp/plugins/remote/remote-config.c
@@ -816,24 +816,28 @@ static int tls_path_parser(struct nv_pair *nv, int line, const char **dest)
 		"TLS support is not enabled, ignoring value at line %d",
 		line);
 #else
-	if (*dest)
-		free((char *)*dest);
 	if (nv->value) {
+		char *tmp;
+
 		if (*nv->value != '/') {
 			syslog(LOG_ERR,
 				"Absolute path needed for %s - line %d",
 				nv->value, line);
 			return 1;
 		}
-		*dest = strdup(nv->value);
-		if (*dest == NULL) {
+		tmp = strdup(nv->value);
+		if (tmp == NULL) {
 			syslog(LOG_ERR,
 				"Out of memory parsing config at line %d",
 				line);
 			return 1;
 		}
-	} else
+		free((char *)*dest);
+		*dest = tmp;
+	} else {
+		free((char *)*dest);
 		*dest = NULL;
+	}
 #endif
 	return 0;
 }
@@ -845,18 +849,21 @@ static int tls_string_parser(struct nv_pair *nv, int line, const char **dest)
 		"TLS support is not enabled, ignoring value at line %d",
 		line);
 #else
-	if (*dest)
-		free((char *)*dest);
 	if (nv->value) {
-		*dest = strdup(nv->value);
-		if (*dest == NULL) {
+		char *tmp = strdup(nv->value);
+
+		if (tmp == NULL) {
 			syslog(LOG_ERR,
 				"Out of memory parsing config at line %d",
 				line);
 			return 1;
 		}
-	} else
+		free((char *)*dest);
+		*dest = tmp;
+	} else {
+		free((char *)*dest);
 		*dest = NULL;
+	}
 #endif
 	return 0;
 }

--- a/audisp/plugins/remote/remote-config.c
+++ b/audisp/plugins/remote/remote-config.c
@@ -121,6 +121,10 @@ static int overflow_action_parser(struct nv_pair *nv, int line,
 		remote_conf_t *config);
 static int tls_require_pqc_parser(struct nv_pair *nv, int line,
 		remote_conf_t *config);
+static int tls_auth_parser(struct nv_pair *nv, int line,
+		remote_conf_t *config);
+static int tls_crypto_profile_parser(struct nv_pair *nv, int line,
+		remote_conf_t *config);
 static int sanity_check(remote_conf_t *config, const char *file);
 
 static const struct kw_pair keywords[] = 
@@ -149,6 +153,8 @@ static const struct kw_pair keywords[] =
   {"tls_cipher_suites",      tls_cipher_suites_parser,         0 },
   {"tls_key_exchange",       tls_key_exchange_parser,          0 },
   {"tls_require_pqc",        tls_require_pqc_parser,           0 },
+  {"tls_auth",               tls_auth_parser,                  0 },
+  {"tls_crypto_profile",     tls_crypto_profile_parser,        0 },
   {"network_failure_action", network_failure_action_parser,	1 },
   {"disk_low_action",        disk_low_action_parser,		1 },
   {"disk_full_action",       disk_full_action_parser,		1 },
@@ -265,6 +271,8 @@ void clear_config(remote_conf_t *config)
 	config->tls_cipher_suites = NULL;
 	config->tls_key_exchange = NULL;
 	config->tls_require_pqc = 0;
+	config->tls_auth = TLS_AUTH_PSK;
+	config->tls_crypto_profile = TLS_PROFILE_STANDARD;
 #endif
 }
 
@@ -884,6 +892,8 @@ TLS_STUB(tls_psk_identity_parser)
 TLS_STUB(tls_cipher_suites_parser)
 TLS_STUB(tls_key_exchange_parser)
 TLS_STUB(tls_require_pqc_parser)
+TLS_STUB(tls_auth_parser)
+TLS_STUB(tls_crypto_profile_parser)
 #undef TLS_STUB
 #endif
 #undef TLS_PARSER
@@ -892,14 +902,51 @@ TLS_STUB(tls_require_pqc_parser)
 static int tls_require_pqc_parser(struct nv_pair *nv, int line,
 		remote_conf_t *config)
 {
-	if (strcasecmp(nv->value, "yes") == 0)
+	if (strcasecmp(nv->value, "yes") == 0) {
 		config->tls_require_pqc = 1;
-	else if (strcasecmp(nv->value, "no") == 0)
+		config->tls_crypto_profile = TLS_PROFILE_PQC;
+	} else if (strcasecmp(nv->value, "no") == 0) {
 		config->tls_require_pqc = 0;
+		// no-op for tls_crypto_profile -- one-directional alias
+	} else {
+		syslog(LOG_ERR,
+			"Value %s for tls_require_pqc is invalid "
+			"at line %d; must be yes or no",
+			nv->value, line);
+		return 1;
+	}
+	return 0;
+}
+
+static int tls_auth_parser(struct nv_pair *nv, int line,
+		remote_conf_t *config)
+{
+	if (strcasecmp(nv->value, "psk") == 0)
+		config->tls_auth = TLS_AUTH_PSK;
 	else {
 		syslog(LOG_ERR,
-			"Option %s must be yes or no at line %d",
-			nv->value, line);
+			"Value '%s' for tls_auth is not valid at "
+			"line %d; only 'psk' is supported in this "
+			"tech preview", nv->value, line);
+		return 1;
+	}
+	return 0;
+}
+
+static int tls_crypto_profile_parser(struct nv_pair *nv, int line,
+		remote_conf_t *config)
+{
+	if (strcasecmp(nv->value, "standard") == 0)
+		config->tls_crypto_profile = TLS_PROFILE_STANDARD;
+	else if (strcasecmp(nv->value, "fips") == 0)
+		config->tls_crypto_profile = TLS_PROFILE_FIPS;
+	else if (strcasecmp(nv->value, "pqc") == 0)
+		config->tls_crypto_profile = TLS_PROFILE_PQC;
+	else {
+		syslog(LOG_ERR,
+			"Value '%s' for tls_crypto_profile is not "
+			"valid at line %d; must be 'standard', "
+			"'fips', or 'pqc'", nv->value, line);
 		return 1;
 	}
 	return 0;
@@ -947,6 +994,13 @@ static int sanity_check(remote_conf_t *config, const char *file)
 				"mutually exclusive");
 			return 1;
 		}
+		if (config->tls_auth == TLS_AUTH_PSK && !have_psk) {
+			syslog(LOG_ERR,
+				"tls_auth=psk requires tls_psk_file; "
+				"certificate-based TLS is not supported "
+				"in this tech preview");
+			return 1;
+		}
 		if (!have_psk && !have_cert) {
 			syslog(LOG_ERR,
 				"transport=tls requires tls_psk_file or "
@@ -960,13 +1014,22 @@ static int sanity_check(remote_conf_t *config, const char *file)
 			return 1;
 		}
 #ifndef HAVE_SSL_GROUP_TO_NAME
-		if (config->tls_require_pqc) {
+		if (config->tls_require_pqc ||
+		    config->tls_crypto_profile == TLS_PROFILE_PQC) {
 			syslog(LOG_ERR,
-				"tls_require_pqc needs OpenSSL >= 3.0 "
+				"PQC crypto profile needs OpenSSL >= 3.0 "
 				"(SSL_group_to_name not available)");
 			return 1;
 		}
 #endif
+		if (config->tls_require_pqc &&
+		    config->tls_crypto_profile != TLS_PROFILE_PQC) {
+			syslog(LOG_ERR,
+				"tls_require_pqc=yes conflicts with "
+				"tls_crypto_profile; use "
+				"tls_crypto_profile=pqc instead");
+			return 1;
+		}
 		if (config->format != F_MANAGED) {
 			syslog(LOG_ERR,
 				"transport=tls requires format=managed");

--- a/audisp/plugins/remote/remote-config.h
+++ b/audisp/plugins/remote/remote-config.h
@@ -32,6 +32,11 @@ typedef enum { FA_IGNORE, FA_SYSLOG, FA_WARN_ONCE_CONT, FA_WARN_ONCE,
 	       FA_SINGLE, FA_HALT, FA_STOP } failure_action_t;
 typedef enum { OA_IGNORE, OA_SYSLOG, OA_SUSPEND, OA_SINGLE,
 	       OA_HALT } overflow_action_t;
+#ifdef HAVE_TLS
+typedef enum { TLS_AUTH_PSK } tls_auth_t;
+typedef enum { TLS_PROFILE_STANDARD, TLS_PROFILE_FIPS,
+		TLS_PROFILE_PQC } tls_crypto_profile_t;
+#endif
 
 typedef struct remote_conf
 {
@@ -59,6 +64,8 @@ typedef struct remote_conf
 	const char *tls_cipher_suites;
 	const char *tls_key_exchange;
 	int tls_require_pqc;
+	tls_auth_t tls_auth;
+	tls_crypto_profile_t tls_crypto_profile;
 #endif
 
 	failure_action_t network_failure_action;

--- a/audisp/plugins/remote/test-tls-helpers.c
+++ b/audisp/plugins/remote/test-tls-helpers.c
@@ -354,6 +354,293 @@ static void test_autls_load_psk_validation(void)
 	unlink(path);
 }
 
+static void test_autls_validate_psk_identity(void)
+{
+	printf("  autls_validate_psk_identity...\n");
+
+	/* Empty and NULL */
+	assert(autls_validate_psk_identity(
+		(const unsigned char *)"", 0, test_log) == -1);
+
+	/* Valid identities */
+	assert(autls_validate_psk_identity(
+		(const unsigned char *)"host-1", 6, test_log) == 0);
+	assert(autls_validate_psk_identity(
+		(const unsigned char *)"a", 1, test_log) == 0);
+	assert(autls_validate_psk_identity(
+		(const unsigned char *)"host.example-01_test", 20,
+		test_log) == 0);
+
+	/* Printable ASCII boundary: 0x21 (!) and 0x7E (~) */
+	assert(autls_validate_psk_identity(
+		(const unsigned char *)"!", 1, test_log) == 0);
+	assert(autls_validate_psk_identity(
+		(const unsigned char *)"~", 1, test_log) == 0);
+
+	/* Space (0x20) rejected */
+	assert(autls_validate_psk_identity(
+		(const unsigned char *)"a b", 3, test_log) == -1);
+
+	/* Control chars rejected */
+	assert(autls_validate_psk_identity(
+		(const unsigned char *)"\t", 1, test_log) == -1);
+	assert(autls_validate_psk_identity(
+		(const unsigned char *)"\n", 1, test_log) == -1);
+	assert(autls_validate_psk_identity(
+		(const unsigned char *)"\x01", 1, test_log) == -1);
+
+	/* NUL byte rejected */
+	assert(autls_validate_psk_identity(
+		(const unsigned char *)"a\x00" "b", 3, test_log) == -1);
+
+	/* DEL (0x7F) rejected */
+	assert(autls_validate_psk_identity(
+		(const unsigned char *)"\x7F", 1, test_log) == -1);
+
+	/* High bytes (0x80-0xFF) rejected */
+	assert(autls_validate_psk_identity(
+		(const unsigned char *)"\x80", 1, test_log) == -1);
+	assert(autls_validate_psk_identity(
+		(const unsigned char *)"\xC0\xAF", 2, test_log) == -1);
+	assert(autls_validate_psk_identity(
+		(const unsigned char *)"\xFF", 1, test_log) == -1);
+
+	/* Max length (255) accepted */
+	{
+		unsigned char buf[256];
+		memset(buf, 'A', 255);
+		assert(autls_validate_psk_identity(
+			buf, 255, test_log) == 0);
+	}
+
+	/* Overlength (256) rejected */
+	{
+		unsigned char buf[257];
+		memset(buf, 'A', 256);
+		assert(autls_validate_psk_identity(
+			buf, 256, test_log) == -1);
+	}
+}
+
+static void test_autls_profile_ciphers(void)
+{
+	printf("  autls_profile_ciphers...\n");
+
+	/* STANDARD returns non-NULL default */
+	assert(autls_profile_ciphers(AUTLS_PROFILE_STANDARD) != NULL);
+	assert(strstr(autls_profile_ciphers(AUTLS_PROFILE_STANDARD),
+		"TLS_AES_256_GCM_SHA384") != NULL);
+
+	/* PQC returns same as STANDARD */
+	assert(autls_profile_ciphers(AUTLS_PROFILE_PQC) != NULL);
+	assert(strcmp(autls_profile_ciphers(AUTLS_PROFILE_PQC),
+		autls_profile_ciphers(AUTLS_PROFILE_STANDARD)) == 0);
+
+	/* FIPS returns NULL (defer to system policy) */
+	assert(autls_profile_ciphers(AUTLS_PROFILE_FIPS) == NULL);
+}
+
+static void test_autls_profile_groups(void)
+{
+	printf("  autls_profile_groups...\n");
+
+	/* STANDARD returns hybrid + classical */
+	assert(autls_profile_groups(AUTLS_PROFILE_STANDARD) != NULL);
+	assert(strstr(autls_profile_groups(AUTLS_PROFILE_STANDARD),
+		"X25519") != NULL);
+
+	/* PQC returns hybrid-only (no plain X25519) */
+	assert(autls_profile_groups(AUTLS_PROFILE_PQC) != NULL);
+	assert(strstr(autls_profile_groups(AUTLS_PROFILE_PQC),
+		"MLKEM") != NULL);
+
+	/* FIPS returns NULL */
+	assert(autls_profile_groups(AUTLS_PROFILE_FIPS) == NULL);
+}
+
+static void test_autls_acl_load(void)
+{
+	struct autls_acl_table *t = NULL;
+	char path[512];
+
+	printf("  autls_acl_load...\n");
+
+	/* Valid file with one enabled, one disabled */
+	snprintf(path, sizeof(path), "%s/acl-valid", tmpdir);
+	write_file(path, "host-1 enabled prod\nhost-2 disabled retired\n");
+	chmod(path, 0600);
+	if (getuid() == 0) {
+		assert(autls_acl_load(path, &t, test_log) == 0);
+		assert(t != NULL);
+		assert(t->count == 2);
+		assert(t->enabled_count == 1);
+		autls_acl_free(t);
+		t = NULL;
+	}
+	unlink(path);
+
+	/* Empty file (no entries) */
+	snprintf(path, sizeof(path), "%s/acl-empty", tmpdir);
+	write_file(path, "# only comments\n\n");
+	chmod(path, 0600);
+	if (getuid() == 0) {
+		assert(autls_acl_load(path, &t, test_log) == 0);
+		assert(t != NULL);
+		assert(t->count == 0);
+		assert(t->enabled_count == 0);
+		autls_acl_free(t);
+		t = NULL;
+	}
+	unlink(path);
+
+	/* Duplicate identity rejected */
+	snprintf(path, sizeof(path), "%s/acl-dup", tmpdir);
+	write_file(path, "host-1 enabled\nhost-1 disabled\n");
+	chmod(path, 0600);
+	if (getuid() == 0) {
+		assert(autls_acl_load(path, &t, test_log) == -1);
+		assert(t == NULL);
+	}
+	unlink(path);
+
+	/* Invalid status rejected */
+	snprintf(path, sizeof(path), "%s/acl-badstatus", tmpdir);
+	write_file(path, "host-1 active\n");
+	chmod(path, 0600);
+	if (getuid() == 0) {
+		assert(autls_acl_load(path, &t, test_log) == -1);
+	}
+	unlink(path);
+
+	/* Missing status field rejected */
+	snprintf(path, sizeof(path), "%s/acl-nostatus", tmpdir);
+	write_file(path, "host-1\n");
+	chmod(path, 0600);
+	if (getuid() == 0) {
+		assert(autls_acl_load(path, &t, test_log) == -1);
+	}
+	unlink(path);
+
+	/* Case-insensitive status */
+	snprintf(path, sizeof(path), "%s/acl-case", tmpdir);
+	write_file(path, "host-1 Enabled\nhost-2 DISABLED\n");
+	chmod(path, 0600);
+	if (getuid() == 0) {
+		assert(autls_acl_load(path, &t, test_log) == 0);
+		assert(t->count == 2);
+		assert(t->enabled_count == 1);
+		autls_acl_free(t);
+		t = NULL;
+	}
+	unlink(path);
+
+	/* Group-writable file rejected */
+	snprintf(path, sizeof(path), "%s/acl-gw", tmpdir);
+	write_file(path, "host-1 enabled\n");
+	chmod(path, 0660);
+	if (getuid() == 0) {
+		assert(autls_acl_load(path, &t, test_log) == -1);
+	}
+	unlink(path);
+}
+
+static void test_autls_acl_check(void)
+{
+	struct autls_acl_table *t = NULL;
+	char path[512];
+
+	printf("  autls_acl_check...\n");
+
+	snprintf(path, sizeof(path), "%s/acl-check", tmpdir);
+	write_file(path, "host-1 enabled\nhost-2 disabled\n");
+	chmod(path, 0600);
+	if (getuid() != 0) {
+		printf("    (skipped, not root)\n");
+		unlink(path);
+		return;
+	}
+	assert(autls_acl_load(path, &t, test_log) == 0);
+	unlink(path);
+
+	/* Enabled returns 1 */
+	assert(autls_acl_check(t,
+		(const unsigned char *)"host-1", 6) == 1);
+
+	/* Disabled returns 0 */
+	assert(autls_acl_check(t,
+		(const unsigned char *)"host-2", 6) == 0);
+
+	/* Unknown returns -1 */
+	assert(autls_acl_check(t,
+		(const unsigned char *)"host-3", 6) == -1);
+
+	/* Empty identity returns -1 */
+	assert(autls_acl_check(t,
+		(const unsigned char *)"", 0) == -1);
+
+	/* Prefix match does NOT succeed (length-bounded) */
+	assert(autls_acl_check(t,
+		(const unsigned char *)"host-1x", 7) == -1);
+	assert(autls_acl_check(t,
+		(const unsigned char *)"host-", 5) == -1);
+
+	autls_acl_free(t);
+}
+
+static void test_autls_authorize_psk_identity(void)
+{
+	struct autls_acl_table *t = NULL;
+	char path[512];
+	int rc;
+
+	printf("  autls_authorize_psk_identity (composed)...\n");
+
+	snprintf(path, sizeof(path), "%s/acl-auth", tmpdir);
+	write_file(path, "good-host enabled\nbad-host disabled\n");
+	chmod(path, 0600);
+	if (getuid() != 0) {
+		printf("    (skipped, not root)\n");
+		unlink(path);
+		return;
+	}
+	assert(autls_acl_load(path, &t, test_log) == 0);
+	unlink(path);
+
+	/* Valid + enabled: validate passes, ACL returns 1 */
+	rc = autls_validate_psk_identity(
+		(const unsigned char *)"good-host", 9, test_log);
+	assert(rc == 0);
+	assert(autls_acl_check(t,
+		(const unsigned char *)"good-host", 9) == 1);
+
+	/* Valid + disabled: validate passes, ACL returns 0 */
+	rc = autls_validate_psk_identity(
+		(const unsigned char *)"bad-host", 8, test_log);
+	assert(rc == 0);
+	assert(autls_acl_check(t,
+		(const unsigned char *)"bad-host", 8) == 0);
+
+	/* Invalid identity: validate fails before ACL check */
+	rc = autls_validate_psk_identity(
+		(const unsigned char *)"bad\x00host", 8, test_log);
+	assert(rc == -1);
+
+	/* Unknown identity: validate passes, ACL returns -1 */
+	rc = autls_validate_psk_identity(
+		(const unsigned char *)"unknown", 7, test_log);
+	assert(rc == 0);
+	assert(autls_acl_check(t,
+		(const unsigned char *)"unknown", 7) == -1);
+
+	/* Catches if(rc) vs if(rc==1) bug: -1 is truthy in C */
+	rc = autls_acl_check(t,
+		(const unsigned char *)"unknown", 7);
+	assert(rc == -1);
+	assert(rc != 1);  /* Must not treat -1 as "enabled" */
+
+	autls_acl_free(t);
+}
+
 int main(void)
 {
 	char template[] = "/tmp/test-tls-XXXXXX";
@@ -371,6 +658,12 @@ int main(void)
 	test_autls_validate_key_file();
 	test_autls_load_psk();
 	test_autls_load_psk_validation();
+	test_autls_validate_psk_identity();
+	test_autls_profile_ciphers();
+	test_autls_profile_groups();
+	test_autls_acl_load();
+	test_autls_acl_check();
+	test_autls_authorize_psk_identity();
 	printf("All TLS helper tests passed.\n");
 	return 0;
 }

--- a/autls/Makefile.am
+++ b/autls/Makefile.am
@@ -21,6 +21,6 @@
 
 AM_CPPFLAGS = -I${top_srcdir}
 noinst_LTLIBRARIES = libautls.la
-libautls_la_SOURCES = autls.h autls-psk.c autls-io.c autls-profile.c
+libautls_la_SOURCES = autls.h autls-psk.c autls-io.c autls-profile.c autls-acl.c
 libautls_la_CFLAGS = $(OPENSSL_CFLAGS)
 libautls_la_LIBADD = $(OPENSSL_LIBS)

--- a/autls/autls-acl.c
+++ b/autls/autls-acl.c
@@ -1,0 +1,265 @@
+/* autls-acl.c -- TLS client ACL file parser
+ * Copyright 2026 Red Hat Inc.
+ * All Rights Reserved.
+ *
+ * This library is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 2.1 of the License, or (at your option) any later version.
+ *
+ * This library is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this library; if not, write to the Free Software
+ * Foundation, Inc., 59 Temple Place, Suite 330, Boston, MA  02111-1307  USA
+ */
+
+#include "config.h"
+#include <errno.h>
+#include <fcntl.h>
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include <strings.h>
+#include <syslog.h>
+#include <sys/stat.h>
+#include <unistd.h>
+#include <openssl/crypto.h>
+#include "autls.h"
+
+/*
+ * autls_acl_load - parse a TLS client authorization file
+ * @path: path to the ACL file
+ * @table: output pointer to the parsed ACL table (caller frees)
+ * @log_fn: logging callback for error reporting
+ *
+ * File format: one entry per line, fields separated by whitespace.
+ *   # identity   status    notes
+ *   host-1234    enabled   prod web host
+ *   host-5678    disabled  retired
+ *
+ * Blank lines and lines starting with # are ignored.
+ * Status must be "enabled" or "disabled" (case-insensitive).
+ * Identity is validated via autls_validate_psk_identity().
+ * Duplicate identities are rejected.
+ * File must be root-owned, not group-writable, not world-writable,
+ * and a regular file. Opened with O_NOFOLLOW to reject symlinks.
+ *
+ * Returns 0 on success, -1 on error.
+ */
+int autls_acl_load(const char *path, struct autls_acl_table **table,
+		   autls_log_fn log_fn)
+{
+	int fd = -1;
+	FILE *f = NULL;
+	struct stat st;
+	struct autls_acl_table *t = NULL;
+	struct autls_acl_entry *tail = NULL;
+	char line[512];
+	int lineno = 0;
+
+	*table = NULL;
+
+	fd = open(path, O_RDONLY | O_NOFOLLOW);
+	if (fd < 0) {
+		log_fn(LOG_ERR, "Unable to open ACL file %s (%s)",
+			path, strerror(errno));
+		return -1;
+	}
+
+	if (fstat(fd, &st) != 0) {
+		log_fn(LOG_ERR, "Unable to stat ACL file %s (%s)",
+			path, strerror(errno));
+		close(fd);
+		return -1;
+	}
+	if (!S_ISREG(st.st_mode)) {
+		log_fn(LOG_ERR, "%s is not a regular file", path);
+		close(fd);
+		return -1;
+	}
+	if (st.st_uid != 0) {
+		log_fn(LOG_ERR, "%s is not owned by root (uid %u)",
+			path, (unsigned)st.st_uid);
+		close(fd);
+		return -1;
+	}
+	if (st.st_mode & 022) {
+		log_fn(LOG_ERR,
+			"%s is group-writable or world-writable "
+			"(mode %#o)", path, st.st_mode & 07777);
+		close(fd);
+		return -1;
+	}
+
+	f = fdopen(fd, "r");
+	if (f == NULL) {
+		log_fn(LOG_ERR, "Unable to read ACL file %s (%s)",
+			path, strerror(errno));
+		close(fd);
+		return -1;
+	}
+
+	t = calloc(1, sizeof(*t));
+	if (t == NULL) {
+		log_fn(LOG_ERR, "Out of memory for ACL table");
+		fclose(f);
+		return -1;
+	}
+
+	while (fgets(line, sizeof(line), f) != NULL) {
+		char *identity, *status, *saveptr;
+		struct autls_acl_entry *entry, *dup;
+		size_t len;
+
+		lineno++;
+
+		len = strlen(line);
+
+		/* Detect truncated lines (no newline, not at EOF) */
+		if (len == sizeof(line) - 1 &&
+		    line[len - 1] != '\n') {
+			int ch;
+			log_fn(LOG_ERR,
+				"%s:%d: line too long (max %zu chars)",
+				path, lineno, sizeof(line) - 2);
+			/* Skip the rest of this line */
+			while ((ch = fgetc(f)) != EOF && ch != '\n')
+				;
+			goto err;
+		}
+
+		if (len > 0 && line[len - 1] == '\n')
+			line[--len] = '\0';
+		if (len > 0 && line[len - 1] == '\r')
+			line[--len] = '\0';
+
+		// Skip blank lines and comments
+		if (len == 0 || line[0] == '#')
+			continue;
+
+		identity = strtok_r(line, " \t", &saveptr);
+		if (identity == NULL)
+			continue;
+
+		status = strtok_r(NULL, " \t", &saveptr);
+		if (status == NULL) {
+			log_fn(LOG_ERR,
+				"%s:%d: missing status field",
+				path, lineno);
+			goto err;
+		}
+
+		if (autls_validate_psk_identity(
+				(const unsigned char *)identity,
+				strlen(identity), log_fn) != 0) {
+			log_fn(LOG_ERR,
+				"%s:%d: invalid identity", path, lineno);
+			goto err;
+		}
+
+		/* Check for duplicates */
+		for (dup = t->entries; dup; dup = dup->next) {
+			if (strcmp(dup->identity, identity) == 0) {
+				log_fn(LOG_ERR,
+					"%s:%d: duplicate identity '%s'",
+					path, lineno, identity);
+				goto err;
+			}
+		}
+
+		entry = calloc(1, sizeof(*entry));
+		if (entry == NULL) {
+			log_fn(LOG_ERR, "Out of memory for ACL entry");
+			goto err;
+		}
+		entry->identity = strdup(identity);
+		if (entry->identity == NULL) {
+			log_fn(LOG_ERR, "Out of memory for identity");
+			free(entry);
+			goto err;
+		}
+
+		if (strcasecmp(status, "enabled") == 0)
+			entry->enabled = 1;
+		else if (strcasecmp(status, "disabled") == 0)
+			entry->enabled = 0;
+		else {
+			log_fn(LOG_ERR,
+				"%s:%d: invalid status '%s'; "
+				"must be 'enabled' or 'disabled'",
+				path, lineno, status);
+			free(entry->identity);
+			free(entry);
+			goto err;
+		}
+
+		/* Append to list */
+		if (tail)
+			tail->next = entry;
+		else
+			t->entries = entry;
+		tail = entry;
+		t->count++;
+		if (entry->enabled)
+			t->enabled_count++;
+	}
+
+	if (ferror(f)) {
+		log_fn(LOG_ERR, "I/O error reading ACL file %s", path);
+		goto err;
+	}
+
+	fclose(f);
+	*table = t;
+	return 0;
+
+err:
+	fclose(f);
+	autls_acl_free(t);
+	return -1;
+}
+
+/*
+ * autls_acl_check - look up an identity in the ACL table
+ * @table: parsed ACL table
+ * @identity: identity bytes to look up
+ * @len: length of @identity in bytes
+ *
+ * Returns 1 if the identity is found and enabled,
+ * 0 if found but disabled, -1 if not found.
+ */
+int autls_acl_check(const struct autls_acl_table *table,
+		    const unsigned char *identity, size_t len)
+{
+	const struct autls_acl_entry *e;
+
+	for (e = table->entries; e != NULL; e = e->next) {
+		if (strlen(e->identity) == len &&
+		    CRYPTO_memcmp(e->identity, identity, len) == 0)
+			return e->enabled ? 1 : 0;
+	}
+	return -1;
+}
+
+/*
+ * autls_acl_free - free an ACL table and all its entries
+ * @table: table to free, may be NULL
+ */
+void autls_acl_free(struct autls_acl_table *table)
+{
+	struct autls_acl_entry *e, *next;
+
+	if (table == NULL)
+		return;
+
+	for (e = table->entries; e != NULL; e = next) {
+		next = e->next;
+		free(e->identity);
+		free(e);
+	}
+	free(table);
+}

--- a/autls/autls-acl.c
+++ b/autls/autls-acl.c
@@ -161,9 +161,12 @@ int autls_acl_load(const char *path, struct autls_acl_table **table,
 			goto err;
 		}
 
+		size_t id_len = strlen(identity);
+
 		/* Check for duplicates */
 		for (dup = t->entries; dup; dup = dup->next) {
-			if (strcmp(dup->identity, identity) == 0) {
+			if (dup->identity_len == id_len &&
+			    memcmp(dup->identity, identity, id_len) == 0) {
 				log_fn(LOG_ERR,
 					"%s:%d: duplicate identity '%s'",
 					path, lineno, identity);
@@ -182,6 +185,7 @@ int autls_acl_load(const char *path, struct autls_acl_table **table,
 			free(entry);
 			goto err;
 		}
+		entry->identity_len = id_len;
 
 		if (strcasecmp(status, "enabled") == 0)
 			entry->enabled = 1;
@@ -238,7 +242,7 @@ int autls_acl_check(const struct autls_acl_table *table,
 	const struct autls_acl_entry *e;
 
 	for (e = table->entries; e != NULL; e = e->next) {
-		if (strlen(e->identity) == len &&
+		if (e->identity_len == len &&
 		    CRYPTO_memcmp(e->identity, identity, len) == 0)
 			return e->enabled ? 1 : 0;
 	}

--- a/autls/autls-profile.c
+++ b/autls/autls-profile.c
@@ -48,6 +48,70 @@ int autls_is_pqc_group(const char *name)
 }
 
 /*
+ * Default TLS 1.3 ciphersuite string for standard and PQC profiles.
+ * SHA-256 ciphers are listed first because RFC 8446 s4.2.11 mandates
+ * SHA-256 as the hash for external PSK binders; AES-256-GCM (SHA-384)
+ * is unreachable in PSK mode unless a SHA-384 binder is selected.
+ */
+#define AUTLS_DEFAULT_CIPHERS \
+	"TLS_AES_128_GCM_SHA256:" \
+	"TLS_CHACHA20_POLY1305_SHA256:" \
+	"TLS_AES_256_GCM_SHA384"
+
+/* Default key exchange groups -- includes PQC hybrid with fallback */
+#define AUTLS_STANDARD_GROUPS	"X25519MLKEM768:X25519"
+
+/* PQC-only hybrid groups -- no classical fallback, no pure ML-KEM */
+#define AUTLS_PQC_GROUPS \
+	"X25519MLKEM768:" \
+	"SecP256r1MLKEM768:" \
+	"SecP384r1MLKEM1024"
+
+/*
+ * autls_profile_ciphers - return the ciphersuite string for a profile
+ * @profile: one of AUTLS_PROFILE_STANDARD, AUTLS_PROFILE_FIPS,
+ *           AUTLS_PROFILE_PQC
+ *
+ * STANDARD and PQC return the default TLS 1.3 ciphersuites.
+ * FIPS returns NULL (defer to system crypto policy).
+ */
+const char *autls_profile_ciphers(int profile)
+{
+	switch (profile) {
+	case AUTLS_PROFILE_STANDARD:
+	case AUTLS_PROFILE_PQC:
+		return AUTLS_DEFAULT_CIPHERS;
+	case AUTLS_PROFILE_FIPS:
+		return NULL;
+	default:
+		return AUTLS_DEFAULT_CIPHERS;
+	}
+}
+
+/*
+ * autls_profile_groups - return the key exchange groups for a profile
+ * @profile: one of AUTLS_PROFILE_STANDARD, AUTLS_PROFILE_FIPS,
+ *           AUTLS_PROFILE_PQC
+ *
+ * STANDARD returns hybrid-plus-classical groups with fallback.
+ * PQC returns hybrid-only groups (no classical fallback).
+ * FIPS returns NULL (defer to system crypto policy).
+ */
+const char *autls_profile_groups(int profile)
+{
+	switch (profile) {
+	case AUTLS_PROFILE_STANDARD:
+		return AUTLS_STANDARD_GROUPS;
+	case AUTLS_PROFILE_PQC:
+		return AUTLS_PQC_GROUPS;
+	case AUTLS_PROFILE_FIPS:
+		return NULL;
+	default:
+		return AUTLS_STANDARD_GROUPS;
+	}
+}
+
+/*
  * autls_find_tls13_cipher - select a TLS 1.3 cipher matching a hash
  * @ssl: active SSL connection
  * @md: required hash algorithm, or NULL for SHA-256 default

--- a/autls/autls-psk.c
+++ b/autls/autls-psk.c
@@ -29,6 +29,43 @@
 #include "autls.h"
 
 /*
+ * autls_validate_psk_identity - validate a PSK identity string
+ * @id: identity bytes to validate
+ * @len: length of @id in bytes
+ * @log_fn: logging callback for error reporting
+ *
+ * Checks that the identity is non-empty, within the maximum length,
+ * and contains only printable ASCII characters (0x21-0x7E).
+ * Returns 0 on success, -1 on validation failure.
+ */
+int autls_validate_psk_identity(const unsigned char *id, size_t len,
+				autls_log_fn log_fn)
+{
+	size_t i;
+
+	if (len == 0) {
+		log_fn(LOG_ERR, "PSK identity is empty");
+		return -1;
+	}
+	if (len > AUTLS_PSK_IDENTITY_MAX) {
+		log_fn(LOG_ERR,
+			"PSK identity too long (%zu bytes, max %d)",
+			len, AUTLS_PSK_IDENTITY_MAX);
+		return -1;
+	}
+	for (i = 0; i < len; i++) {
+		if (id[i] < 0x21 || id[i] > 0x7E) {
+			log_fn(LOG_ERR,
+				"PSK identity contains invalid byte "
+				"0x%02x at position %zu",
+				id[i], i);
+			return -1;
+		}
+	}
+	return 0;
+}
+
+/*
  * autls_validate_key_file - verify a TLS key file has safe permissions
  * @path: path to the key file
  * @log_fn: logging callback for error reporting

--- a/autls/autls-psk.c
+++ b/autls/autls-psk.c
@@ -25,7 +25,10 @@
 #include <syslog.h>
 #include <sys/stat.h>
 #include <unistd.h>
+#include <openssl/bio.h>
 #include <openssl/crypto.h>
+#include <openssl/evp.h>
+#include <openssl/pem.h>
 #include "autls.h"
 
 /*
@@ -106,6 +109,91 @@ int autls_validate_key_file(const char *path, autls_log_fn log_fn)
 }
 
 /*
+ * autls_load_key_file - validate and load a PEM private key atomically
+ * @path: path to the PEM key file
+ * @ctx: SSL_CTX to load the key into
+ * @log_fn: logging callback
+ *
+ * Opens with O_NOFOLLOW and validates via fstat on the open fd,
+ * eliminating the TOCTOU race of separate validate-then-open.
+ * Returns 0 on success, -1 on failure.
+ */
+int autls_load_key_file(const char *path, SSL_CTX *ctx,
+			autls_log_fn log_fn)
+{
+	struct stat st;
+	int fd;
+	BIO *bio;
+	EVP_PKEY *pkey;
+
+	fd = open(path, O_RDONLY | O_NOFOLLOW);
+	if (fd < 0) {
+		log_fn(LOG_ERR,
+			"Unable to open TLS key file %s (%s)",
+			path, strerror(errno));
+		return -1;
+	}
+
+	if (fstat(fd, &st) != 0) {
+		log_fn(LOG_ERR,
+			"Unable to stat TLS key file %s (%s)",
+			path, strerror(errno));
+		close(fd);
+		return -1;
+	}
+	if (!S_ISREG(st.st_mode)) {
+		log_fn(LOG_ERR, "%s is not a regular file", path);
+		close(fd);
+		return -1;
+	}
+	if ((st.st_mode & 07777) != 0400) {
+		log_fn(LOG_ERR,
+			"%s is not mode 0400 (it's %#o) "
+			"- compromised key?",
+			path, st.st_mode & 07777);
+		close(fd);
+		return -1;
+	}
+	if (st.st_uid != 0) {
+		log_fn(LOG_ERR,
+			"%s is not owned by root (uid %u) "
+			"- compromised key?",
+			path, (unsigned)st.st_uid);
+		close(fd);
+		return -1;
+	}
+
+	bio = BIO_new_fd(fd, BIO_NOCLOSE);
+	if (bio == NULL) {
+		log_fn(LOG_ERR,
+			"Unable to create BIO for TLS key file %s",
+			path);
+		close(fd);
+		return -1;
+	}
+
+	pkey = PEM_read_bio_PrivateKey(bio, NULL, NULL, NULL);
+	BIO_free(bio);
+	close(fd);
+
+	if (pkey == NULL) {
+		log_fn(LOG_ERR,
+			"Unable to read PEM private key from %s", path);
+		return -1;
+	}
+
+	if (SSL_CTX_use_PrivateKey(ctx, pkey) != 1) {
+		log_fn(LOG_ERR,
+			"Unable to load TLS private key %s", path);
+		EVP_PKEY_free(pkey);
+		return -1;
+	}
+
+	EVP_PKEY_free(pkey);
+	return 0;
+}
+
+/*
  * autls_load_psk - validate and read a hex-encoded pre-shared key
  * @path: path to the PSK file (single line of hex)
  * @key: output pointer to decoded key bytes (caller frees with OPENSSL_free)
@@ -179,7 +267,11 @@ int autls_load_psk(const char *path, unsigned char **key, size_t *key_len,
 	// fd is now owned by f; do not close(fd) separately
 
 	if (fgets(line, sizeof(line), f) == NULL) {
-		log_fn(LOG_ERR, "PSK file %s is empty", path);
+		if (ferror(f))
+			log_fn(LOG_ERR,
+				"I/O error reading PSK file %s", path);
+		else
+			log_fn(LOG_ERR, "PSK file %s is empty", path);
 		fclose(f);
 		goto cleanup;
 	}

--- a/autls/autls.h
+++ b/autls/autls.h
@@ -59,6 +59,9 @@ const char *autls_profile_groups(int profile)
 /* autls-psk.c */
 int autls_validate_key_file(const char *path, autls_log_fn log_fn)
 	__nonnull((1, 2)) __wur;
+int autls_load_key_file(const char *path, SSL_CTX *ctx,
+			autls_log_fn log_fn)
+	__nonnull((1, 2, 3)) __wur;
 int autls_load_psk(const char *path, unsigned char **key, size_t *key_len,
 		   autls_log_fn log_fn)
 	__nonnull((1, 2, 3, 4)) __wur;

--- a/autls/autls.h
+++ b/autls/autls.h
@@ -69,6 +69,7 @@ int autls_validate_psk_identity(const unsigned char *id, size_t len,
 /* autls-acl.c */
 struct autls_acl_entry {
 	char *identity;
+	size_t identity_len;
 	int enabled;
 	struct autls_acl_entry *next;
 };

--- a/autls/autls.h
+++ b/autls/autls.h
@@ -66,6 +66,27 @@ int autls_validate_psk_identity(const unsigned char *id, size_t len,
 				autls_log_fn log_fn)
 	__nonnull((1, 3)) __wur;
 
+/* autls-acl.c */
+struct autls_acl_entry {
+	char *identity;
+	int enabled;
+	struct autls_acl_entry *next;
+};
+
+struct autls_acl_table {
+	struct autls_acl_entry *entries;
+	int count;
+	int enabled_count;
+};
+
+int autls_acl_load(const char *path, struct autls_acl_table **table,
+		   autls_log_fn log_fn)
+	__nonnull((1, 2, 3)) __wur;
+int autls_acl_check(const struct autls_acl_table *table,
+		    const unsigned char *identity, size_t len)
+	__nonnull((1, 2)) __wur;
+void autls_acl_free(struct autls_acl_table *table);
+
 /* autls-io.c */
 int autls_remaining_ms(const struct timespec *deadline)
 	__nonnull((1)) __wur;

--- a/autls/autls.h
+++ b/autls/autls.h
@@ -35,11 +35,26 @@ typedef void (*autls_log_fn)(int, const char *, ...)
 #define AUTLS_WRITE_TIMEOUT_MS		100
 #define AUTLS_SHUTDOWN_TIMEOUT_MS	1000
 
+/* PSK identity limits */
+#define AUTLS_PSK_IDENTITY_MAX		255
+
+/*
+ * Crypto profile values -- must match tls_crypto_profile_t
+ * in auditd-config.h and remote-config.h
+ */
+#define AUTLS_PROFILE_STANDARD		0
+#define AUTLS_PROFILE_FIPS		1
+#define AUTLS_PROFILE_PQC		2
+
 /* autls-profile.c */
 int autls_is_pqc_group(const char *name)
 	__attribute_pure__ __wur;
 const SSL_CIPHER *autls_find_tls13_cipher(SSL *ssl, const EVP_MD *md)
 	__nonnull((1)) __wur;
+const char *autls_profile_ciphers(int profile)
+	__attribute_pure__ __wur;
+const char *autls_profile_groups(int profile)
+	__attribute_pure__ __wur;
 
 /* autls-psk.c */
 int autls_validate_key_file(const char *path, autls_log_fn log_fn)
@@ -47,6 +62,9 @@ int autls_validate_key_file(const char *path, autls_log_fn log_fn)
 int autls_load_psk(const char *path, unsigned char **key, size_t *key_len,
 		   autls_log_fn log_fn)
 	__nonnull((1, 2, 3, 4)) __wur;
+int autls_validate_psk_identity(const unsigned char *id, size_t len,
+				autls_log_fn log_fn)
+	__nonnull((1, 3)) __wur;
 
 /* autls-io.c */
 int autls_remaining_ms(const struct timespec *deadline)

--- a/configure.ac
+++ b/configure.ac
@@ -285,8 +285,15 @@ AC_ARG_ENABLE(tls,
 	[want_tls="no"]
 )
 if test x$want_tls = xyes; then
-	AC_CHECK_LIB(ssl, SSL_CTX_new, [OPENSSL_LIBS="-lssl -lcrypto"],
-		[AC_MSG_ERROR([TLS support requires OpenSSL (libssl)])])
+	if test "x$OPENSSL_LIBS" = "x"; then
+		AC_CHECK_LIB(ssl, SSL_CTX_new,
+			[OPENSSL_LIBS="-lssl -lcrypto"],
+			[AC_MSG_ERROR(
+				[TLS support requires OpenSSL (libssl)])])
+	else
+		AC_MSG_NOTICE(
+			[using user-supplied OPENSSL_LIBS: $OPENSSL_LIBS])
+	fi
 	AC_CHECK_LIB(crypto, OPENSSL_hexstr2buf, [:],
 		[AC_MSG_ERROR([TLS support requires OpenSSL (libcrypto)])])
 	AC_CHECK_HEADER(openssl/ssl.h, [],
@@ -324,9 +331,9 @@ if test x$want_tls = xyes; then
 	LIBS="$saved_LIBS"
 	AC_DEFINE(HAVE_TLS,, Define if you want to use TLS transport)
 	OPENSSL_CFLAGS="${OPENSSL_CFLAGS-}"
-	AC_SUBST(OPENSSL_CFLAGS)
-	AC_SUBST(OPENSSL_LIBS)
 fi
+AC_SUBST(OPENSSL_CFLAGS)
+AC_SUBST(OPENSSL_LIBS)
 AM_CONDITIONAL(ENABLE_TLS, test x$want_tls = xyes)
 
 # ids

--- a/docs/auditd.conf.5
+++ b/docs/auditd.conf.5
@@ -360,35 +360,58 @@ Path to the server TLS private key in PEM format. The file must be owned by root
 .I tls_ca_file
 Path to the CA certificate used to verify client certificates when mutual TLS is enabled via tls_client_auth.
 .TP
+.I tls_auth
+The TLS authentication mode. Currently only
+.I psk
+is supported (pre-shared key authentication). Certificate-based TLS authentication is not supported in this tech preview. The default is
+.IR psk .
+.TP
+.I tls_crypto_profile
+Selects the cryptographic profile for TLS. Valid values are
+.IR standard ", " fips ", and " pqc .
+.I standard
+uses robust classical TLS 1.3 PSK with opportunistic PQC hybrid key exchange.
+.I fips
+defers all cipher and group selection to the system crypto policy (RHEL crypto-policies) and fails closed if the policy does not support TLS 1.3.
+.I pqc
+requires post-quantum hybrid key exchange and rejects connections that negotiate a classical-only group. The default is
+.IR standard .
+.TP
 .I tls_psk_file
 Path to a file containing a hex-encoded pre-shared key for TLS-PSK authentication. The key must be at least 32 bytes (64 hex characters). Generate a key with: openssl rand \-hex 32. The file must be owned by root and mode 0400.
 .TP
 .I tls_psk_identity
 The expected client PSK identity string. This option is required when tls_psk_file is set and tls_allowed_clients is not configured. The server rejects clients that present a different identity. The identity must contain only printable ASCII characters (no spaces or control characters) and must not exceed 255 bytes.
 .TP
+.I tls_allowed_clients
+Path to a file listing authorized PSK client identities. The file format is one entry per line: identity, status (enabled or disabled), and optional notes separated by whitespace. Lines starting with # are comments. Example:
+.nf
+.RS
+# identity   status    notes
+host-1234    enabled   prod web host
+host-5678    disabled  retired
+.RE
+.fi
+When this option is set, it is the sole authorization source for PSK connections; tls_psk_identity is ignored. The file must be owned by root, not group-writable, and not world-writable. In the current single-PSK model (one tls_psk_file), at most one identity may be enabled. A full per-identity PSK store is planned for a future release.
+.TP
 .I tls_cipher_suites
-Colon-separated list of TLS 1.3 cipher suites. The default is "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256".
+Colon-separated list of TLS 1.3 cipher suites. Overrides the profile default. The default is "TLS_AES_128_GCM_SHA256:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_256_GCM_SHA384".
 .TP
 .I tls_key_exchange
-Colon-separated list of key exchange groups. The default is "X25519MLKEM768:X25519" which uses post-quantum hybrid key exchange as the primary option. PQC hybrid key exchange increases handshake sizes by approximately 1120 bytes, which may require updates to network middleboxes with deep packet inspection.
+Colon-separated list of key exchange groups. Overrides the profile default. Overrides cannot weaken a PQC profile's post-handshake group check. PQC hybrid key exchange increases handshake sizes by approximately 1120 bytes, which may require updates to network middleboxes with deep packet inspection.
 .TP
 .I tls_require_pqc
-If set to
+Compatibility alias for tls_crypto_profile=pqc. If set to
 .IR yes ,
-the server will refuse to start when post-quantum key exchange groups are not available, and will reject connections that negotiate a classical-only group. When set to
-.IR no
-(the default), the server will fall back to classical-only key exchange. PSK mode with PQC key exchange provides fully quantum-resistant transport. Certificate mode provides quantum-resistant confidentiality but authentication relies on classical signatures until ML-DSA certificates are deployed.
+sets tls_crypto_profile to pqc. If set to
+.IR no ,
+it has no effect on tls_crypto_profile (one-directional alias). New configurations should use tls_crypto_profile directly.
 .TP
 .I tls_client_auth
-Controls client certificate verification for mutual TLS. Valid values are
+Controls client certificate verification for mutual TLS (certificate mode only). Valid values are
 .IR none ", " optional ", and " required ".
-If set to
-.IR required ,
-clients must present a valid certificate (matching tls_ca_file). If set to
-.IR optional ,
-client certificates are requested but not required. The default is
-.IR required
-to match the mutual authentication behavior of the Kerberos transport.
+This option is ignored when tls_auth=psk. The default is
+.IR none .
 .TP
 .I distribute_network
 If set to "yes", network originating events will be distributed to the audit

--- a/docs/auditd.conf.5
+++ b/docs/auditd.conf.5
@@ -457,7 +457,7 @@ and
 .I verify_email
 .
 .SH NOTES
-Changes to TLS configuration options (tls_cert_file, tls_key_file, tls_ca_file, tls_psk_file, tls_cipher_suites, tls_key_exchange, tls_require_pqc, tls_client_auth) require a full daemon restart to take effect. Sending SIGHUP will not reload TLS settings.
+Changes to TLS configuration options (tls_cert_file, tls_key_file, tls_ca_file, tls_psk_file, tls_psk_identity, tls_cipher_suites, tls_key_exchange, tls_require_pqc, tls_client_auth, tls_auth, tls_crypto_profile) require a full daemon restart to take effect. The tls_allowed_clients ACL file is reloaded on SIGHUP without restarting the daemon.
 .PP
 In a CAPP environment, the audit trail is considered so important that access to system resources must be denied if an audit trail cannot be created. In this environment, it would be suggested that /var/log/audit be on its own partition. This is to ensure that space detection is accurate and that no other process comes along and consumes part of it.
 .PP

--- a/docs/auditd.conf.5
+++ b/docs/auditd.conf.5
@@ -364,7 +364,7 @@ Path to the CA certificate used to verify client certificates when mutual TLS is
 Path to a file containing a hex-encoded pre-shared key for TLS-PSK authentication. The key must be at least 32 bytes (64 hex characters). Generate a key with: openssl rand \-hex 32. The file must be owned by root and mode 0400.
 .TP
 .I tls_psk_identity
-The expected client PSK identity string. This option is required when tls_psk_file is set. The server rejects clients that present a different identity. Set this to match the client's tls_psk_identity value.
+The expected client PSK identity string. This option is required when tls_psk_file is set and tls_allowed_clients is not configured. The server rejects clients that present a different identity. The identity must contain only printable ASCII characters (no spaces or control characters) and must not exceed 255 bytes.
 .TP
 .I tls_cipher_suites
 Colon-separated list of TLS 1.3 cipher suites. The default is "TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256".

--- a/init.d/auditd.conf
+++ b/init.d/auditd.conf
@@ -34,16 +34,20 @@ transport = TCP
 krb5_principal = auditd
 ##krb5_key_file = /etc/audit/audit.key
 ## TLS transport options (requires transport = tls)
-## Configure either tls_psk_file or tls_cert_file+tls_key_file
-##tls_cert_file = /etc/audit/tls/server-cert.pem
-##tls_key_file = /etc/audit/tls/server-key.pem
-##tls_ca_file = /etc/audit/tls/ca-cert.pem
+##tls_auth = psk
+##tls_crypto_profile = standard
 ##tls_psk_file = /etc/audit/tls/audit.psk
-##tls_psk_identity = audit-client
+##tls_psk_identity = my-collector-01
+##tls_allowed_clients = /etc/audit/tls/allowed_clients
+## Advanced overrides (override profile defaults):
 ##tls_cipher_suites = TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256
 ##tls_key_exchange = X25519MLKEM768:X25519
 ##tls_require_pqc = no
-##tls_client_auth = required
+## Certificate mode (not supported in this tech preview):
+##tls_cert_file = /etc/audit/tls/server-cert.pem
+##tls_key_file = /etc/audit/tls/server-key.pem
+##tls_ca_file = /etc/audit/tls/ca-cert.pem
+##tls_client_auth = none
 distribute_network = no
 q_depth = 2000
 overflow_action = SYSLOG

--- a/src/Makefile.am
+++ b/src/Makefile.am
@@ -38,6 +38,9 @@ auditd_CFLAGS += -I${top_srcdir}/autls $(OPENSSL_CFLAGS)
 endif
 auditd_LDFLAGS = -pie -Wl,-z,relro -Wl,-z,now
 auditd_DEPENDENCIES = libev/libev.a
+if ENABLE_TLS
+auditd_DEPENDENCIES += ${top_builddir}/autls/libautls.la
+endif
 auditd_LDADD = @LIBWRAP_LIBS@ ${top_builddir}/src/libev/libev.la ${top_builddir}/audisp/libdisp.la ${top_builddir}/lib/libaudit.la ${top_builddir}/auparse/libauparse.la -lpthread -lm $(gss_libs) ${top_builddir}/common/libaucommon.la
 if ENABLE_TLS
 auditd_LDADD += ${top_builddir}/autls/libautls.la

--- a/src/auditd-config.c
+++ b/src/auditd-config.c
@@ -155,6 +155,8 @@ static int tls_auth_parser(const struct nv_pair *nv, int line,
 		struct daemon_conf *config);
 static int tls_crypto_profile_parser(const struct nv_pair *nv, int line,
 		struct daemon_conf *config);
+static int tls_allowed_clients_parser(const struct nv_pair *nv, int line,
+		struct daemon_conf *config);
 static int distribute_network_parser(const struct nv_pair *nv, int line,
 		struct daemon_conf *config);
 static int q_depth_parser(const struct nv_pair *nv, int line,
@@ -248,6 +250,7 @@ static const struct kw_pair keywords[] =
   {"tls_require_pqc",          tls_require_pqc_parser,          0 },
   {"tls_auth",                 tls_auth_parser,                 0 },
   {"tls_crypto_profile",       tls_crypto_profile_parser,       0 },
+  {"tls_allowed_clients",      tls_allowed_clients_parser,      0 },
   {"distribute_network",       distribute_network_parser,       0 },
   {"q_depth",                  q_depth_parser,                  0 },
   {"overflow_action",          overflow_action_parser,          0 },
@@ -426,6 +429,7 @@ void clear_config(struct daemon_conf *config)
 	config->tls_require_pqc = 0;
 	config->tls_auth = TLS_AUTH_PSK;
 	config->tls_crypto_profile = TLS_PROFILE_STANDARD;
+	config->tls_allowed_clients = NULL;
 #endif
 	config->distribute_network_events = 0;
 	config->q_depth = 2000;
@@ -1906,6 +1910,7 @@ TLS_PARSER_S(tls_psk_file_parser, tls_psk_file, tls_path_parser_s)
 TLS_PARSER_S(tls_psk_identity_parser, tls_psk_identity, tls_string_parser_s)
 TLS_PARSER_S(tls_cipher_suites_parser, tls_cipher_suites, tls_string_parser_s)
 TLS_PARSER_S(tls_key_exchange_parser, tls_key_exchange, tls_string_parser_s)
+TLS_PARSER_S(tls_allowed_clients_parser, tls_allowed_clients, tls_path_parser_s)
 
 static int tls_client_auth_parser(const struct nv_pair *nv, int line,
 		struct daemon_conf *config)
@@ -1997,6 +2002,7 @@ TLS_STUB_S(tls_client_auth_parser)
 TLS_STUB_S(tls_require_pqc_parser)
 TLS_STUB_S(tls_auth_parser)
 TLS_STUB_S(tls_crypto_profile_parser)
+TLS_STUB_S(tls_allowed_clients_parser)
 #undef TLS_STUB_S
 #endif
 #undef TLS_PARSER_S
@@ -2321,10 +2327,11 @@ static int sanity_check(struct daemon_conf *config)
 				"tls_cert_file+tls_key_file");
 			return 1;
 		}
-		if (have_psk && !config->tls_psk_identity) {
+		if (have_psk && !config->tls_psk_identity &&
+		    !config->tls_allowed_clients) {
 			audit_msg(LOG_ERR,
-				"tls_psk_identity is required when "
-				"tls_psk_file is set");
+				"tls_psk_identity or tls_allowed_clients "
+				"is required when tls_psk_file is set");
 			return 1;
 		}
 #ifndef HAVE_SSL_GROUP_TO_NAME
@@ -2410,6 +2417,7 @@ void free_config(struct daemon_conf *config)
 	free((void *)config->tls_psk_identity);
 	free((void *)config->tls_cipher_suites);
 	free((void *)config->tls_key_exchange);
+	free((void *)config->tls_allowed_clients);
 #endif
 	free((void *)config->plugin_dir);
 	free((void *)config_dir);

--- a/src/auditd-config.c
+++ b/src/auditd-config.c
@@ -1860,14 +1860,7 @@ static int tls_path_parser_s(const struct nv_pair *nv, int line,
 				nv->value, line);
 			return 1;
 		}
-		free((char *)*dest);
-		*dest = strdup(nv->value);
-		if (*dest == NULL) {
-			audit_msg(LOG_ERR,
-				"Out of memory parsing config at line %d",
-				line);
-			return 1;
-		}
+		return replace_string(dest, nv->value, nv->name, line);
 	}
 #endif
 	return 0;
@@ -1881,16 +1874,8 @@ static int tls_string_parser_s(const struct nv_pair *nv, int line,
 		"TLS support is not enabled, ignoring value at line %d",
 		line);
 #else
-	if (nv->value) {
-		free((char *)*dest);
-		*dest = strdup(nv->value);
-		if (*dest == NULL) {
-			audit_msg(LOG_ERR,
-				"Out of memory parsing config at line %d",
-				line);
-			return 1;
-		}
-	}
+	if (nv->value)
+		return replace_string(dest, nv->value, nv->name, line);
 #endif
 	return 0;
 }

--- a/src/auditd-config.c
+++ b/src/auditd-config.c
@@ -151,6 +151,10 @@ static int tls_client_auth_parser(const struct nv_pair *nv, int line,
 		struct daemon_conf *config);
 static int tls_require_pqc_parser(const struct nv_pair *nv, int line,
 		struct daemon_conf *config);
+static int tls_auth_parser(const struct nv_pair *nv, int line,
+		struct daemon_conf *config);
+static int tls_crypto_profile_parser(const struct nv_pair *nv, int line,
+		struct daemon_conf *config);
 static int distribute_network_parser(const struct nv_pair *nv, int line,
 		struct daemon_conf *config);
 static int q_depth_parser(const struct nv_pair *nv, int line,
@@ -242,6 +246,8 @@ static const struct kw_pair keywords[] =
   {"tls_key_exchange",         tls_key_exchange_parser,         0 },
   {"tls_client_auth",          tls_client_auth_parser,          0 },
   {"tls_require_pqc",          tls_require_pqc_parser,          0 },
+  {"tls_auth",                 tls_auth_parser,                 0 },
+  {"tls_crypto_profile",       tls_crypto_profile_parser,       0 },
   {"distribute_network",       distribute_network_parser,       0 },
   {"q_depth",                  q_depth_parser,                  0 },
   {"overflow_action",          overflow_action_parser,          0 },
@@ -416,8 +422,10 @@ void clear_config(struct daemon_conf *config)
 	config->tls_psk_identity = NULL;
 	config->tls_cipher_suites = NULL;
 	config->tls_key_exchange = NULL;
-	config->tls_client_auth = TCA_REQUIRED;
+	config->tls_client_auth = TCA_NONE;
 	config->tls_require_pqc = 0;
+	config->tls_auth = TLS_AUTH_PSK;
+	config->tls_crypto_profile = TLS_PROFILE_STANDARD;
 #endif
 	config->distribute_network_events = 0;
 	config->q_depth = 2000;
@@ -1919,14 +1927,51 @@ static int tls_client_auth_parser(const struct nv_pair *nv, int line,
 static int tls_require_pqc_parser(const struct nv_pair *nv, int line,
 		struct daemon_conf *config)
 {
-	if (strcasecmp(nv->value, "yes") == 0)
+	if (strcasecmp(nv->value, "yes") == 0) {
 		config->tls_require_pqc = 1;
-	else if (strcasecmp(nv->value, "no") == 0)
+		config->tls_crypto_profile = TLS_PROFILE_PQC;
+	} else if (strcasecmp(nv->value, "no") == 0) {
 		config->tls_require_pqc = 0;
+		// no-op for tls_crypto_profile -- one-directional alias
+	} else {
+		audit_msg(LOG_ERR,
+			"Value %s for tls_require_pqc is invalid "
+			"at line %d; must be yes or no",
+			nv->value, line);
+		return 1;
+	}
+	return 0;
+}
+
+static int tls_auth_parser(const struct nv_pair *nv, int line,
+		struct daemon_conf *config)
+{
+	if (strcasecmp(nv->value, "psk") == 0)
+		config->tls_auth = TLS_AUTH_PSK;
 	else {
 		audit_msg(LOG_ERR,
-			"Option %s must be yes or no at line %d",
-			nv->value, line);
+			"Value '%s' for tls_auth is not valid at "
+			"line %d; only 'psk' is supported in this "
+			"tech preview", nv->value, line);
+		return 1;
+	}
+	return 0;
+}
+
+static int tls_crypto_profile_parser(const struct nv_pair *nv, int line,
+		struct daemon_conf *config)
+{
+	if (strcasecmp(nv->value, "standard") == 0)
+		config->tls_crypto_profile = TLS_PROFILE_STANDARD;
+	else if (strcasecmp(nv->value, "fips") == 0)
+		config->tls_crypto_profile = TLS_PROFILE_FIPS;
+	else if (strcasecmp(nv->value, "pqc") == 0)
+		config->tls_crypto_profile = TLS_PROFILE_PQC;
+	else {
+		audit_msg(LOG_ERR,
+			"Value '%s' for tls_crypto_profile is not "
+			"valid at line %d; must be 'standard', "
+			"'fips', or 'pqc'", nv->value, line);
 		return 1;
 	}
 	return 0;
@@ -1950,6 +1995,8 @@ TLS_STUB_S(tls_cipher_suites_parser)
 TLS_STUB_S(tls_key_exchange_parser)
 TLS_STUB_S(tls_client_auth_parser)
 TLS_STUB_S(tls_require_pqc_parser)
+TLS_STUB_S(tls_auth_parser)
+TLS_STUB_S(tls_crypto_profile_parser)
 #undef TLS_STUB_S
 #endif
 #undef TLS_PARSER_S
@@ -2261,6 +2308,13 @@ static int sanity_check(struct daemon_conf *config)
 				"mutually exclusive");
 			return 1;
 		}
+		if (config->tls_auth == TLS_AUTH_PSK && !have_psk) {
+			audit_msg(LOG_ERR,
+				"tls_auth=psk requires tls_psk_file; "
+				"certificate-based TLS is not supported "
+				"in this tech preview");
+			return 1;
+		}
 		if (!have_psk && !have_cert) {
 			audit_msg(LOG_ERR,
 				"transport=tls requires tls_psk_file or "
@@ -2274,13 +2328,29 @@ static int sanity_check(struct daemon_conf *config)
 			return 1;
 		}
 #ifndef HAVE_SSL_GROUP_TO_NAME
-		if (config->tls_require_pqc) {
+		if (config->tls_require_pqc ||
+		    config->tls_crypto_profile == TLS_PROFILE_PQC) {
 			audit_msg(LOG_ERR,
-				"tls_require_pqc needs OpenSSL >= 3.0 "
+				"PQC crypto profile needs OpenSSL >= 3.0 "
 				"(SSL_group_to_name not available)");
 			return 1;
 		}
 #endif
+		if (config->tls_require_pqc &&
+		    config->tls_crypto_profile != TLS_PROFILE_PQC) {
+			audit_msg(LOG_ERR,
+				"tls_require_pqc=yes conflicts with "
+				"tls_crypto_profile; use "
+				"tls_crypto_profile=pqc instead");
+			return 1;
+		}
+		if (config->tls_client_auth > TCA_NONE &&
+				config->tls_auth == TLS_AUTH_PSK) {
+			audit_msg(LOG_WARNING,
+				"tls_client_auth is ignored when "
+				"tls_auth=psk; PSK identity "
+				"authorization is used instead");
+		}
 		if (have_cert && config->tls_client_auth > TCA_NONE &&
 				!config->tls_ca_file) {
 			audit_msg(LOG_ERR,

--- a/src/auditd-config.h
+++ b/src/auditd-config.h
@@ -47,6 +47,9 @@ typedef enum { O_IGNORE, O_SYSLOG, O_SUSPEND, O_SINGLE,
 typedef enum { T_TCP, T_TLS, T_KRB5, T_LABELED } transport_t;
 #ifdef HAVE_TLS
 typedef enum { TCA_NONE, TCA_OPTIONAL, TCA_REQUIRED } tls_client_auth_t;
+typedef enum { TLS_AUTH_PSK } tls_auth_t;
+typedef enum { TLS_PROFILE_STANDARD, TLS_PROFILE_FIPS,
+		TLS_PROFILE_PQC } tls_crypto_profile_t;
 #endif
 
 struct daemon_conf
@@ -105,6 +108,8 @@ struct daemon_conf
 	const char *tls_key_exchange;
 	tls_client_auth_t tls_client_auth;
 	int tls_require_pqc;
+	tls_auth_t tls_auth;
+	tls_crypto_profile_t tls_crypto_profile;
 #endif
 	int distribute_network_events;
 	// Dispatcher config

--- a/src/auditd-config.h
+++ b/src/auditd-config.h
@@ -110,6 +110,7 @@ struct daemon_conf
 	int tls_require_pqc;
 	tls_auth_t tls_auth;
 	tls_crypto_profile_t tls_crypto_profile;
+	const char *tls_allowed_clients;
 #endif
 	int distribute_network_events;
 	// Dispatcher config

--- a/src/auditd-listen.c
+++ b/src/auditd-listen.c
@@ -1838,17 +1838,9 @@ static int init_tls_server_context(struct daemon_conf *config)
 	}
 
 	if (config->tls_key_file) {
-		if (autls_validate_key_file(config->tls_key_file,
-				audit_msg) != 0)
+		if (autls_load_key_file(config->tls_key_file,
+				tls_server_ctx, audit_msg) != 0)
 			goto err;
-		if (SSL_CTX_use_PrivateKey_file(tls_server_ctx,
-				config->tls_key_file,
-				SSL_FILETYPE_PEM) != 1) {
-			audit_msg(LOG_ERR,
-				"Unable to load TLS private key %s",
-				config->tls_key_file);
-			goto err;
-		}
 	}
 
 	/* Verify cert and key match */
@@ -2090,6 +2082,18 @@ void auditd_tcp_listen_uninit(struct ev_loop *loop, struct daemon_conf *config)
 #ifdef HAVE_TLS
 	while (handshake_chain)
 		abort_handshake(loop, handshake_chain, "shutdown");
+#endif
+
+	while (client_chain) {
+		unsigned char ack[AUDIT_RMW_HEADER_SIZE];
+
+		AUDIT_RMW_PACK_HEADER (ack, 0, AUDIT_RMW_TYPE_ENDING, 0, 0);
+		client_ack(client_chain, ack, "");
+		ev_io_stop(loop, &client_chain->io);
+		close_client(client_chain);
+	}
+
+#ifdef HAVE_TLS
 	if (tls_server_ctx) {
 		SSL_CTX_free(tls_server_ctx);
 		tls_server_ctx = NULL;
@@ -2114,15 +2118,6 @@ void auditd_tcp_listen_uninit(struct ev_loop *loop, struct daemon_conf *config)
 		my_service_name = NULL;
 	}
 #endif
-
-	while (client_chain) {
-		unsigned char ack[AUDIT_RMW_HEADER_SIZE];
-
-		AUDIT_RMW_PACK_HEADER (ack, 0, AUDIT_RMW_TYPE_ENDING, 0, 0);
-		client_ack(client_chain, ack, "");
-		ev_io_stop(loop, &client_chain->io);
-		close_client(client_chain);
-	}
 
 	if (config->tcp_client_max_idle)
 		ev_periodic_stop(loop, &periodic_watcher);
@@ -2180,6 +2175,7 @@ void auditd_tcp_listen_reconfigure(const struct daemon_conf *nconf,
 					"restart; port change ignored");
 				oconf->tcp_listen_port = nconf->tcp_listen_port;
 				oconf->tcp_listen_queue = nconf->tcp_listen_queue;
+				oconf->transport = nconf->transport;
 			} else
 #endif
 			{

--- a/src/auditd-listen.c
+++ b/src/auditd-listen.c
@@ -64,6 +64,13 @@
 extern int send_audit_event(int type, const char *str);
 #define DEFAULT_BUF_SZ  192
 
+#ifdef HAVE_TLS
+_Static_assert(AUTLS_PROFILE_STANDARD == TLS_PROFILE_STANDARD &&
+	       AUTLS_PROFILE_FIPS == TLS_PROFILE_FIPS &&
+	       AUTLS_PROFILE_PQC == TLS_PROFILE_PQC,
+	       "autls profile constants out of sync with config enums");
+#endif
+
 typedef struct ev_tcp {
 	struct ev_io io;
 	struct sockaddr_storage addr;
@@ -1037,7 +1044,8 @@ static void tls_handshake_handler(struct ev_loop *loop,
 			SSL_get_cipher(client->ssl),
 			kex_name ? kex_name : "unknown");
 
-		if (client->config->tls_require_pqc &&
+		if (client->config->tls_crypto_profile ==
+		    TLS_PROFILE_PQC &&
 		    !autls_is_pqc_group(kex_name)) {
 			audit_msg(LOG_ERR,
 				"PQC key exchange required but "
@@ -1433,29 +1441,48 @@ static int init_tls_server_context(struct daemon_conf *config)
 
 	cipher_suites = config->tls_cipher_suites ?
 		config->tls_cipher_suites :
-		"TLS_AES_256_GCM_SHA384:TLS_CHACHA20_POLY1305_SHA256:TLS_AES_128_GCM_SHA256";
-	if (!SSL_CTX_set_ciphersuites(tls_server_ctx, cipher_suites)) {
-		audit_msg(LOG_ERR, "Unable to set TLS cipher suites");
-		goto err;
-	}
-
-	key_exchange = config->tls_key_exchange ?
-		config->tls_key_exchange : "X25519MLKEM768:X25519";
-	if (!SSL_CTX_set1_groups_list(tls_server_ctx, key_exchange)) {
-		ERR_clear_error();
-		if (config->tls_require_pqc || config->tls_key_exchange) {
+		autls_profile_ciphers(config->tls_crypto_profile);
+	if (cipher_suites) {
+		if (!SSL_CTX_set_ciphersuites(tls_server_ctx,
+					      cipher_suites)) {
 			audit_msg(LOG_ERR,
-				"Unable to set key exchange groups '%s'",
-				key_exchange);
+				"Unable to set TLS cipher suites");
 			goto err;
 		}
+	}
+
+	if (config->tls_crypto_profile == TLS_PROFILE_PQC &&
+	    config->tls_key_exchange)
 		audit_msg(LOG_WARNING,
-			"PQC key exchange groups not available, "
-			"falling back to X25519");
-		if (!SSL_CTX_set1_groups_list(tls_server_ctx, "X25519")) {
-			audit_msg(LOG_ERR,
-				"Unable to set any key exchange groups");
-			goto err;
+			"tls_key_exchange override set with PQC "
+			"profile; connections will fail if override "
+			"excludes PQC groups");
+
+	key_exchange = config->tls_key_exchange ?
+		config->tls_key_exchange :
+		autls_profile_groups(config->tls_crypto_profile);
+	if (key_exchange) {
+		if (!SSL_CTX_set1_groups_list(tls_server_ctx,
+					      key_exchange)) {
+			ERR_print_errors_cb(tls_error_cb, NULL);
+			if (config->tls_crypto_profile !=
+			    TLS_PROFILE_STANDARD ||
+			    config->tls_key_exchange) {
+				audit_msg(LOG_ERR,
+					"Unable to set key exchange "
+					"groups '%s'", key_exchange);
+				goto err;
+			}
+			audit_msg(LOG_WARNING,
+				"PQC key exchange groups not "
+				"available, falling back to X25519");
+			if (!SSL_CTX_set1_groups_list(tls_server_ctx,
+						      "X25519")) {
+				audit_msg(LOG_ERR,
+					"Unable to set any key "
+					"exchange groups");
+				goto err;
+			}
 		}
 	}
 
@@ -1531,6 +1558,7 @@ static int init_tls_server_context(struct daemon_conf *config)
 
 	return 0;
 err:
+	ERR_print_errors_cb(tls_error_cb, NULL);
 	if (server_psk_key) {
 		OPENSSL_cleanse(server_psk_key, server_psk_key_len);
 		OPENSSL_free(server_psk_key);

--- a/src/auditd-listen.c
+++ b/src/auditd-listen.c
@@ -210,11 +210,81 @@ static void close_client(struct ev_tcp *client)
 }
 
 #ifdef HAVE_TLS
+#define TLS_AUDIT_BUF_SZ 768
+
+/* Map crypto profile enum to string for audit records */
+static const char *profile_name(int profile)
+{
+	switch (profile) {
+	case TLS_PROFILE_STANDARD: return "standard";
+	case TLS_PROFILE_FIPS:     return "fips";
+	case TLS_PROFILE_PQC:      return "pqc";
+	default:                   return "unknown";
+	}
+}
+
+/*
+ * emit_tls_audit_record - format and emit a structured TLS audit record
+ * @addr: peer address
+ * @ssl: SSL connection (may be NULL for pre-handshake failures)
+ * @profile: crypto profile enum value for the audit record
+ * @identity: accepted or attempted identity (may be NULL)
+ * @reason: stable failure reason or "success"
+ * @result: "success" or "no"
+ */
+static void emit_tls_audit_record(const struct sockaddr_storage *addr,
+				  SSL *ssl, int profile,
+				  const char *identity, const char *reason,
+				  const char *result)
+{
+	char emsg[TLS_AUDIT_BUF_SZ];
+	const char *tlsver = "none";
+	const char *cipher = "none";
+	const char *group = "unknown";
+
+	if (ssl) {
+		tlsver = SSL_get_version(ssl);
+		cipher = SSL_get_cipher(ssl);
+#ifdef HAVE_SSL_GROUP_TO_NAME
+		{
+			const char *g = SSL_group_to_name(ssl,
+				SSL_get_negotiated_group(ssl));
+			if (g)
+				group = g;
+		}
+#endif
+	}
+
+	snprintf(emsg, sizeof(emsg),
+		"op=tls-accept res=%s role=collector addr=%s port=%u "
+		"id=%.128s profile=%s reason=%s auth=psk "
+		"tls_version=%s cipher=%s group=%s",
+		result,
+		sockaddr_to_string(addr), sockaddr_to_port(addr),
+		identity ? identity : "?",
+		profile_name(profile),
+		reason, tlsver, cipher, group);
+	send_audit_event(AUDIT_DAEMON_ACCEPT, emsg);
+}
+
+/*
+ * tls_error_cb - OpenSSL error queue drain callback
+ *
+ * Logs each queued OpenSSL error via audit_msg so that TLS handshake
+ * failures produce actionable diagnostics on the server side.
+ * Returns 1 to continue draining.
+ */
+static int tls_error_cb(const char *str, size_t len, void *u)
+{
+	audit_msg(LOG_ERR, "TLS error: %.*s", (int)len, str);
+	return 1;
+}
+
 static void abort_handshake(struct ev_loop *loop,
 		struct ev_tcp *client, const char *op)
 {
-	char emsg[DEFAULT_BUF_SZ];
 	char *ex_identity = NULL;
+	const char *ex_reason = NULL;
 
 	ev_io_stop(loop, &client->io);
 	ev_timer_stop(loop, &client->handshake_timer);
@@ -227,6 +297,17 @@ static void abort_handshake(struct ev_loop *loop,
 			SSL_set_ex_data(client->ssl,
 					ssl_ex_idx_identity, NULL);
 		}
+		if (ssl_ex_idx_reason >= 0)
+			ex_reason = SSL_get_ex_data(client->ssl,
+						ssl_ex_idx_reason);
+	}
+
+	emit_tls_audit_record(&client->addr, client->ssl,
+			      client->tls_profile_at_accept, ex_identity,
+			      ex_reason ? ex_reason : op, "no");
+
+	if (client->ssl) {
+		ERR_print_errors_cb(tls_error_cb, NULL);
 		SSL_free(client->ssl);
 		client->ssl = NULL;
 	}
@@ -243,11 +324,6 @@ static void abort_handshake(struct ev_loop *loop,
 		handshake_count--;
 		client->in_handshake_chain = 0;
 	}
-
-	snprintf(emsg, sizeof(emsg), "op=%s addr=%s port=%u res=no",
-		op, sockaddr_to_string(&client->addr),
-		sockaddr_to_port(&client->addr));
-	send_audit_event(AUDIT_DAEMON_ACCEPT, emsg);
 
 	free(ex_identity);
 	free(client->accepted_identity);
@@ -1042,7 +1118,6 @@ static void tls_handshake_handler(struct ev_loop *loop,
 	struct ev_tcp *client = (struct ev_tcp *)_io;
 	int ret, err;
 	const char *kex_name;
-	char emsg[DEFAULT_BUF_SZ];
 
 	ret = SSL_do_handshake(client->ssl);
 	if (ret == 1) {
@@ -1116,11 +1191,10 @@ static void tls_handshake_handler(struct ev_loop *loop,
 			client->next->prev = client;
 		client_chain = client;
 
-		snprintf(emsg, sizeof(emsg),
-			"addr=%s port=%u res=success",
-			sockaddr_to_string(&client->addr),
-			sockaddr_to_port(&client->addr));
-		send_audit_event(AUDIT_DAEMON_ACCEPT, emsg);
+		emit_tls_audit_record(&client->addr, client->ssl,
+				      client->tls_profile_at_accept,
+				      client->accepted_identity,
+				      "success", "success");
 		return;
 	}
 
@@ -1508,6 +1582,11 @@ static int tls_psk_find_session_cb(SSL *ssl, const unsigned char *identity,
 		char *id_copy = strndup((const char *)identity,
 					identity_len);
 		free(old);
+		if (id_copy == NULL)
+			audit_msg(LOG_WARNING,
+				"Out of memory for PSK identity; "
+				"connection will lack identity "
+				"attribution");
 		SSL_set_ex_data(ssl, ssl_ex_idx_identity, id_copy);
 	}
 

--- a/src/auditd-listen.c
+++ b/src/auditd-listen.c
@@ -88,6 +88,7 @@ typedef struct ev_tcp {
 	struct ev_timer handshake_timer;
 	struct daemon_conf *config;
 	int in_handshake_chain;
+	int tls_profile_at_accept;
 	char *accepted_identity;
 #endif
 	unsigned char buffer [MAX_AUDIT_MESSAGE_LENGTH + 17];
@@ -1136,7 +1137,7 @@ static void tls_handshake_handler(struct ev_loop *loop,
 			SSL_get_cipher(client->ssl),
 			kex_name ? kex_name : "unknown");
 
-		if (client->config->tls_crypto_profile ==
+		if (client->tls_profile_at_accept ==
 		    TLS_PROFILE_PQC &&
 		    !autls_is_pqc_group(kex_name)) {
 			audit_msg(LOG_ERR,
@@ -1353,6 +1354,8 @@ static void auditd_tcp_listen_handler( struct ev_loop *loop,
 		SSL_set_accept_state(client->ssl);
 
 		client->config = lconfig;
+		client->tls_profile_at_accept =
+			lconfig->tls_crypto_profile;
 		client->client_active = 0;
 		client->in_handshake_chain = 0;
 
@@ -2139,11 +2142,12 @@ void auditd_tcp_listen_reconfigure(const struct daemon_conf *nconf,
 	oconf->krb5_principal = nconf->krb5_principal;
 
 #ifdef HAVE_TLS
-	/* TLS config changes require a full restart */
+	/* TLS context not reloaded — restart required for cert/key/PSK
+	 * changes. The ACL table IS reloaded below. */
 	if (oconf->transport == T_TLS || nconf->transport == T_TLS)
 		audit_msg(LOG_NOTICE,
-			"TLS settings not reloaded; restart auditd "
-			"to apply TLS config changes");
+			"TLS context not reloaded; restart auditd "
+			"to apply cert/key/PSK config changes");
 	free((void *)oconf->tls_cert_file);
 	oconf->tls_cert_file = nconf->tls_cert_file;
 	free((void *)oconf->tls_key_file);
@@ -2158,8 +2162,50 @@ void auditd_tcp_listen_reconfigure(const struct daemon_conf *nconf,
 	oconf->tls_cipher_suites = nconf->tls_cipher_suites;
 	free((void *)oconf->tls_key_exchange);
 	oconf->tls_key_exchange = nconf->tls_key_exchange;
-	oconf->tls_client_auth = nconf->tls_client_auth;
-	oconf->tls_require_pqc = nconf->tls_require_pqc;
+	/* Integer fields that must match the live SSL_CTX are NOT
+	 * updated here — they only change on restart when
+	 * init_tls_server_context rebuilds the context. */
+	free((void *)oconf->tls_allowed_clients);
+	oconf->tls_allowed_clients = nconf->tls_allowed_clients;
+
+	/* Reload ACL table on SIGHUP — independent of SSL_CTX */
+	if (USE_TLS && oconf->tls_allowed_clients) {
+		struct autls_acl_table *new_acl = NULL;
+		if (autls_acl_load(oconf->tls_allowed_clients,
+				   &new_acl, audit_msg) == 0) {
+			if (server_psk_key &&
+			    new_acl->enabled_count > 1) {
+				audit_msg(LOG_ERR,
+					"Reloaded ACL has %d enabled "
+					"identities but single-PSK "
+					"mode allows at most 1; "
+					"keeping current ACL",
+					new_acl->enabled_count);
+				autls_acl_free(new_acl);
+			} else {
+				int old_enabled = acl_table ?
+					acl_table->enabled_count : 0;
+				autls_acl_free(acl_table);
+				acl_table = new_acl;
+				audit_msg(LOG_NOTICE,
+					"TLS client ACL reloaded "
+					"(%d->%d enabled)",
+					old_enabled,
+					new_acl->enabled_count);
+			}
+		} else {
+			audit_msg(LOG_ERR,
+				"Failed to reload TLS client ACL; "
+				"keeping current ACL");
+		}
+	} else if (USE_TLS && !oconf->tls_allowed_clients
+		   && acl_table) {
+		audit_msg(LOG_NOTICE,
+			"tls_allowed_clients removed; "
+			"clearing ACL");
+		autls_acl_free(acl_table);
+		acl_table = NULL;
+	}
 #endif
 }
 

--- a/src/auditd-listen.c
+++ b/src/auditd-listen.c
@@ -88,6 +88,7 @@ typedef struct ev_tcp {
 	struct ev_timer handshake_timer;
 	struct daemon_conf *config;
 	int in_handshake_chain;
+	char *accepted_identity;
 #endif
 	unsigned char buffer [MAX_AUDIT_MESSAGE_LENGTH + 17];
 } ev_tcp;
@@ -114,6 +115,9 @@ static SSL_CTX *tls_server_ctx = NULL;
 static struct ev_tcp *handshake_chain = NULL;
 static unsigned int handshake_count = 0;
 #define MAX_HANDSHAKE_PENDING 32
+static struct autls_acl_table *acl_table = NULL;
+static int ssl_ex_idx_identity = -1;
+static int ssl_ex_idx_reason = -1;
 #endif
 
 static char *sockaddr_to_string(const struct sockaddr_storage *addr)
@@ -182,6 +186,8 @@ static void release_client(struct ev_tcp *client)
 		SSL_free(client->ssl);
 		client->ssl = NULL;
 	}
+	free(client->accepted_identity);
+	client->accepted_identity = NULL;
 #endif
 #ifdef USE_GSSAPI
 	if (client->remote_name)
@@ -208,10 +214,19 @@ static void abort_handshake(struct ev_loop *loop,
 		struct ev_tcp *client, const char *op)
 {
 	char emsg[DEFAULT_BUF_SZ];
+	char *ex_identity = NULL;
 
 	ev_io_stop(loop, &client->io);
 	ev_timer_stop(loop, &client->handshake_timer);
+
+	/* Retrieve ex-data before SSL_free destroys the SSL object */
 	if (client->ssl) {
+		if (ssl_ex_idx_identity >= 0) {
+			ex_identity = SSL_get_ex_data(client->ssl,
+						ssl_ex_idx_identity);
+			SSL_set_ex_data(client->ssl,
+					ssl_ex_idx_identity, NULL);
+		}
 		SSL_free(client->ssl);
 		client->ssl = NULL;
 	}
@@ -234,6 +249,8 @@ static void abort_handshake(struct ev_loop *loop,
 		sockaddr_to_port(&client->addr));
 	send_audit_event(AUDIT_DAEMON_ACCEPT, emsg);
 
+	free(ex_identity);
+	free(client->accepted_identity);
 	free(client);
 }
 #endif
@@ -1058,6 +1075,15 @@ static void tls_handshake_handler(struct ev_loop *loop,
 			return;
 		}
 
+		/* Transfer accepted identity from ex-data to client */
+		if (ssl_ex_idx_identity >= 0) {
+			client->accepted_identity =
+				SSL_get_ex_data(client->ssl,
+						ssl_ex_idx_identity);
+			SSL_set_ex_data(client->ssl,
+					ssl_ex_idx_identity, NULL);
+		}
+
 		/* Remove from handshake_chain */
 		if (client->in_handshake_chain) {
 			if (handshake_chain == client)
@@ -1341,6 +1367,29 @@ static size_t server_psk_key_len = 0;
 
 static char *expected_psk_identity = NULL;
 
+/* Store a failure reason in SSL ex-data for audit records */
+static void set_psk_failure_reason(SSL *ssl, const char *reason)
+{
+	if (ssl_ex_idx_reason >= 0)
+		SSL_set_ex_data(ssl, ssl_ex_idx_reason, (void *)reason);
+}
+
+/* Sanitize an identity for logging (non-printable → '.') */
+static void sanitize_identity(const unsigned char *id, size_t len,
+			      char *buf, size_t bufsz)
+{
+	size_t log_len, j;
+
+	if (bufsz == 0)
+		return;
+	log_len = len < bufsz - 1 ? len : bufsz - 1;
+
+	for (j = 0; j < log_len; j++)
+		buf[j] = (id[j] >= 0x20 && id[j] <= 0x7E)
+			 ? (char)id[j] : '.';
+	buf[log_len] = '\0';
+}
+
 /*
  * tls_psk_find_session_cb - TLS 1.3 server PSK callback
  * @ssl: SSL connection handle
@@ -1349,8 +1398,9 @@ static char *expected_psk_identity = NULL;
  * @sess: output SSL_SESSION containing the matched PSK
  *
  * Called by OpenSSL during TLS 1.3 handshake to look up the PSK for
- * a client identity. Validates the identity against the configured
- * expected identity using constant-time comparison.
+ * a client identity. Validates the identity, checks it against the
+ * ACL table (if configured) or expected_psk_identity (if not), and
+ * stores the accepted identity in SSL ex-data for later retrieval.
  * Returns 1 on success, 0 on failure or identity mismatch.
  */
 static int tls_psk_find_session_cb(SSL *ssl, const unsigned char *identity,
@@ -1358,49 +1408,110 @@ static int tls_psk_find_session_cb(SSL *ssl, const unsigned char *identity,
 {
 	SSL_SESSION *s;
 	const SSL_CIPHER *cipher;
+	char safe_id[65];
 
 	if (server_psk_key == NULL)
 		return 0;
 
-	/* Validate client identity if configured */
-	if (expected_psk_identity) {
+	/* Validate identity syntax before any authorization check */
+	if (autls_validate_psk_identity(identity, identity_len,
+					audit_msg) != 0) {
+		sanitize_identity(identity, identity_len,
+				  safe_id, sizeof(safe_id));
+		audit_msg(LOG_ERR,
+			"TLS PSK invalid identity: '%s'%s",
+			safe_id,
+			identity_len > 64 ? " (truncated)" : "");
+		set_psk_failure_reason(ssl, "invalid-identity");
+		return 0;
+	}
+
+	/* Authorization: ACL table supersedes single identity */
+	if (acl_table) {
+		int rc = autls_acl_check(acl_table, identity,
+					 identity_len);
+		if (rc < 0) {
+			sanitize_identity(identity, identity_len,
+					  safe_id, sizeof(safe_id));
+			audit_msg(LOG_ERR,
+				"TLS PSK unknown identity: '%s'",
+				safe_id);
+			set_psk_failure_reason(ssl,
+					       "unknown-identity");
+			return 0;
+		}
+		if (rc == 0) {
+			sanitize_identity(identity, identity_len,
+					  safe_id, sizeof(safe_id));
+			audit_msg(LOG_ERR,
+				"TLS PSK disabled identity: '%s'",
+				safe_id);
+			set_psk_failure_reason(ssl,
+					       "disabled-identity");
+			return 0;
+		}
+	} else if (expected_psk_identity) {
 		if (identity_len != strlen(expected_psk_identity) ||
 		    CRYPTO_memcmp(identity, expected_psk_identity,
 				  identity_len) != 0) {
-			char safe_id[65];
-			size_t log_len = identity_len < 64 ?
-					 identity_len : 64;
-			size_t j;
-			for (j = 0; j < log_len; j++)
-				safe_id[j] = (identity[j] >= 0x20 &&
-					      identity[j] <= 0x7E)
-					     ? (char)identity[j] : '.';
-			safe_id[log_len] = '\0';
+			sanitize_identity(identity, identity_len,
+					  safe_id, sizeof(safe_id));
 			audit_msg(LOG_ERR,
 				"TLS PSK identity mismatch: "
 				"received '%s'%s", safe_id,
 				identity_len > 64 ?
 				" (truncated)" : "");
+			set_psk_failure_reason(ssl,
+					       "unknown-identity");
 			return 0;
 		}
+	} else {
+		/* No authorization configured -- fail closed */
+		audit_msg(LOG_ERR,
+			"TLS PSK rejected: no identity authorization "
+			"configured");
+		set_psk_failure_reason(ssl, "no-authorization");
+		return 0;
 	}
 
 	cipher = autls_find_tls13_cipher(ssl, NULL);
-	if (cipher == NULL)
+	if (cipher == NULL) {
+		audit_msg(LOG_ERR,
+			"TLS PSK: no cipher matches PSK hash");
+		set_psk_failure_reason(ssl, "no-matching-cipher");
 		return 0;
+	}
 
 	s = SSL_SESSION_new();
-	if (s == NULL)
+	if (s == NULL) {
+		audit_msg(LOG_ERR,
+			"TLS PSK: SSL_SESSION_new failed");
+		set_psk_failure_reason(ssl, "session-alloc-failed");
 		return 0;
+	}
 
 	if (!SSL_SESSION_set1_master_key(s, server_psk_key,
 					server_psk_key_len) ||
 	    !SSL_SESSION_set_cipher(s, cipher) ||
 	    !SSL_SESSION_set_protocol_version(s, TLS1_3_VERSION)) {
+		audit_msg(LOG_ERR,
+			"TLS PSK: SSL session setup failed");
 		SSL_SESSION_free(s);
+		set_psk_failure_reason(ssl, "session-setup-failed");
 		return 0;
 	}
 
+	/* Store accepted identity in ex-data after session is built
+	 * successfully -- avoids leaking the strndup on failure */
+	if (ssl_ex_idx_identity >= 0) {
+		char *old = SSL_get_ex_data(ssl, ssl_ex_idx_identity);
+		char *id_copy = strndup((const char *)identity,
+					identity_len);
+		free(old);
+		SSL_set_ex_data(ssl, ssl_ex_idx_identity, id_copy);
+	}
+
+	set_psk_failure_reason(ssl, NULL);
 	*sess = s;
 	return 1;
 }
@@ -1511,6 +1622,48 @@ static int init_tls_server_context(struct daemon_conf *config)
 				goto err;
 			}
 		}
+
+		/* Load client ACL if configured */
+		if (config->tls_allowed_clients) {
+			if (acl_table) {
+				autls_acl_free(acl_table);
+				acl_table = NULL;
+			}
+			if (autls_acl_load(config->tls_allowed_clients,
+					   &acl_table, audit_msg) != 0)
+				goto err;
+			if (acl_table->enabled_count > 1) {
+				audit_msg(LOG_ERR,
+					"tls_allowed_clients has %d "
+					"enabled identities but "
+					"single-PSK mode allows at "
+					"most 1",
+					acl_table->enabled_count);
+				goto err;
+			}
+			if (expected_psk_identity)
+				audit_msg(LOG_NOTICE,
+					"tls_allowed_clients is "
+					"configured; tls_psk_identity "
+					"is ignored for authorization");
+		}
+
+		/* Register ex-data indices (once) */
+		if (ssl_ex_idx_identity < 0) {
+			ssl_ex_idx_identity =
+				SSL_get_ex_new_index(0, NULL,
+						     NULL, NULL, NULL);
+			ssl_ex_idx_reason =
+				SSL_get_ex_new_index(0, NULL,
+						     NULL, NULL, NULL);
+			if (ssl_ex_idx_identity < 0 ||
+			    ssl_ex_idx_reason < 0)
+				audit_msg(LOG_WARNING,
+					"Unable to allocate SSL "
+					"ex-data indices; audit "
+					"records may lack identity/"
+					"reason fields");
+		}
 	}
 
 	/* Server certificate */
@@ -1573,6 +1726,8 @@ err:
 	}
 	free(expected_psk_identity);
 	expected_psk_identity = NULL;
+	autls_acl_free(acl_table);
+	acl_table = NULL;
 	SSL_CTX_free(tls_server_ctx);
 	tls_server_ctx = NULL;
 	return -1;
@@ -1787,6 +1942,8 @@ void auditd_tcp_listen_uninit(struct ev_loop *loop, struct daemon_conf *config)
 	}
 	free(expected_psk_identity);
 	expected_psk_identity = NULL;
+	autls_acl_free(acl_table);
+	acl_table = NULL;
 #endif
 #ifdef USE_GSSAPI
 	if (USE_GSS) {

--- a/src/auditd-listen.c
+++ b/src/auditd-listen.c
@@ -90,6 +90,8 @@ typedef struct ev_tcp {
 	int in_handshake_chain;
 	int tls_profile_at_accept;
 	char *accepted_identity;
+	unsigned char *pending_ack;
+	int pending_ack_len;
 #endif
 	unsigned char buffer [MAX_AUDIT_MESSAGE_LENGTH + 17];
 } ev_tcp;
@@ -189,6 +191,8 @@ static void release_client(struct ev_tcp *client)
 	}
 	free(client->accepted_identity);
 	client->accepted_identity = NULL;
+	free(client->pending_ack);
+	client->pending_ack = NULL;
 #endif
 #ifdef USE_GSSAPI
 	if (client->remote_name)
@@ -676,7 +680,11 @@ static void client_ack(void *ack_data, const unsigned char *header,
 #define MAX_ACK_MSG_SIZE 256
 	if (USE_TLS && io->ssl) {
 		unsigned char buf[AUDIT_RMW_HEADER_SIZE + MAX_ACK_MSG_SIZE];
-		int total;
+		int total, ret, err;
+
+		/* Drop stale pending ACK — client will see the latest */
+		free(io->pending_ack);
+		io->pending_ack = NULL;
 
 		memcpy(buf, header, AUDIT_RMW_HEADER_SIZE);
 		total = AUDIT_RMW_HEADER_SIZE;
@@ -684,19 +692,40 @@ static void client_ack(void *ack_data, const unsigned char *header,
 			int mlen = strlen(msg);
 			if (mlen > MAX_ACK_MSG_SIZE)
 				mlen = MAX_ACK_MSG_SIZE;
-			/* Repack length field to match truncated body;
-			 * the caller packed strlen(msg) which may differ */
 			_AUDIT_RMW_PUTN16(buf, 10, mlen);
 			memcpy(buf + AUDIT_RMW_HEADER_SIZE, msg, mlen);
 			total += mlen;
 		}
-		if (autls_ssl_write(io->ssl, buf, total,
-				AUTLS_WRITE_TIMEOUT_MS) < 0) {
-			audit_msg(LOG_ERR,
-				"TLS send ack to %s failed",
-				sockaddr_to_addr(&io->addr));
-			shutdown(io->io.fd, SHUT_RDWR);
+
+		ret = SSL_write(io->ssl, buf, total);
+		if (ret == total)
+			return;
+
+		err = SSL_get_error(io->ssl, ret);
+		if (err == SSL_ERROR_WANT_WRITE ||
+		    err == SSL_ERROR_WANT_READ) {
+			io->pending_ack = malloc(total);
+			if (io->pending_ack) {
+				memcpy(io->pending_ack, buf, total);
+				io->pending_ack_len = total;
+				ev_io_stop(EV_DEFAULT, &io->io);
+				if (err == SSL_ERROR_WANT_WRITE)
+					ev_io_modify(&io->io, EV_WRITE);
+				else
+					ev_io_modify(&io->io, EV_READ);
+				ev_io_start(EV_DEFAULT, &io->io);
+			} else {
+				audit_msg(LOG_ERR,
+					"TLS ACK to %s lost: "
+					"out of memory",
+					sockaddr_to_addr(&io->addr));
+			}
+			return;
 		}
+
+		audit_msg(LOG_ERR, "TLS send ack to %s failed",
+			sockaddr_to_addr(&io->addr));
+		shutdown(io->io.fd, SHUT_RDWR);
 		return;
 	}
 #undef MAX_ACK_MSG_SIZE
@@ -806,6 +835,49 @@ static void auditd_tcp_client_handler(struct ev_loop *loop,
 read_more:
 #ifdef HAVE_TLS
 	if (USE_TLS && io->ssl) {
+		/* Drain any pending ACK write before reading */
+		if (io->pending_ack) {
+			int ret = SSL_write(io->ssl, io->pending_ack,
+					    io->pending_ack_len);
+			if (ret == io->pending_ack_len) {
+				free(io->pending_ack);
+				io->pending_ack = NULL;
+
+				/* Process leftover data from a prior
+				 * batch before reading from SSL */
+				if (io->bufptr > 0) {
+					r = io->bufptr;
+					io->bufptr = 0;
+					goto more_messages;
+				}
+			} else {
+				int err = SSL_get_error(io->ssl, ret);
+				if (err == SSL_ERROR_WANT_WRITE ||
+				    err == SSL_ERROR_WANT_READ) {
+					ev_io_stop(loop, _io);
+					if (err == SSL_ERROR_WANT_WRITE)
+						ev_io_modify(_io, EV_WRITE);
+					else
+						ev_io_modify(_io, EV_READ);
+					ev_io_start(loop, _io);
+					return;
+				}
+				audit_msg(LOG_ERR,
+					"TLS pending ack to %s failed",
+					sockaddr_to_addr(&io->addr));
+				ev_io_stop(loop, _io);
+				close_client(io);
+				return;
+			}
+		}
+
+		/* Re-arm for reading after draining pending write */
+		if (_io->events & EV_WRITE) {
+			ev_io_stop(loop, _io);
+			ev_io_modify(_io, EV_READ);
+			ev_io_start(loop, _io);
+		}
+
 		r = SSL_read(io->ssl,
 			io->buffer + io->bufptr,
 			MAX_AUDIT_MESSAGE_LENGTH - io->bufptr);
@@ -982,6 +1054,10 @@ more_messages:
 
 	/* See if this packet had more than one message in it. */
 	if (io->bufptr > 0) {
+#ifdef HAVE_TLS
+		if (USE_TLS && io->pending_ack)
+			return;
+#endif
 		r = io->bufptr;
 		io->bufptr = 0;
 		goto more_messages;
@@ -1630,6 +1706,8 @@ static int init_tls_server_context(struct daemon_conf *config)
 		goto err;
 	}
 	SSL_CTX_set_options(tls_server_ctx, SSL_OP_NO_COMPRESSION);
+	SSL_CTX_set_mode(tls_server_ctx,
+			 SSL_MODE_ACCEPT_MOVING_WRITE_BUFFER);
 	SSL_CTX_set_session_cache_mode(tls_server_ctx, SSL_SESS_CACHE_OFF);
 
 	cipher_suites = config->tls_cipher_suites ?

--- a/src/auditd-listen.c
+++ b/src/auditd-listen.c
@@ -1497,6 +1497,12 @@ static int init_tls_server_context(struct daemon_conf *config)
 		free(expected_psk_identity);
 		expected_psk_identity = NULL;
 		if (config->tls_psk_identity) {
+			if (autls_validate_psk_identity(
+					(const unsigned char *)
+					config->tls_psk_identity,
+					strlen(config->tls_psk_identity),
+					audit_msg) != 0)
+				goto err;
 			expected_psk_identity =
 				strdup(config->tls_psk_identity);
 			if (!expected_psk_identity) {

--- a/src/test/auditd_config_alloc_test.c
+++ b/src/test/auditd_config_alloc_test.c
@@ -155,11 +155,94 @@ static void test_set_config_dir_preserves_old_value(void)
 	config_file = NULL;
 }
 
+#ifdef HAVE_TLS
+static void test_tls_auth_parser(void)
+{
+	struct daemon_conf config;
+	struct nv_pair nv;
+
+	memset(&config, 0, sizeof(config));
+	reset_allocs(-1);
+
+	/* Valid value: psk */
+	nv = (struct nv_pair){ "tls_auth", "psk", NULL };
+	assert(tls_auth_parser(&nv, 1, &config) == 0);
+	assert(config.tls_auth == TLS_AUTH_PSK);
+
+	/* Invalid value rejected */
+	nv = (struct nv_pair){ "tls_auth", "certificate", NULL };
+	assert(tls_auth_parser(&nv, 1, &config) == 1);
+}
+
+static void test_tls_crypto_profile_parser(void)
+{
+	struct daemon_conf config;
+	struct nv_pair nv;
+
+	memset(&config, 0, sizeof(config));
+	reset_allocs(-1);
+
+	nv = (struct nv_pair){ "tls_crypto_profile", "standard", NULL };
+	assert(tls_crypto_profile_parser(&nv, 1, &config) == 0);
+	assert(config.tls_crypto_profile == TLS_PROFILE_STANDARD);
+
+	nv = (struct nv_pair){ "tls_crypto_profile", "fips", NULL };
+	assert(tls_crypto_profile_parser(&nv, 1, &config) == 0);
+	assert(config.tls_crypto_profile == TLS_PROFILE_FIPS);
+
+	nv = (struct nv_pair){ "tls_crypto_profile", "pqc", NULL };
+	assert(tls_crypto_profile_parser(&nv, 1, &config) == 0);
+	assert(config.tls_crypto_profile == TLS_PROFILE_PQC);
+
+	/* Invalid value rejected */
+	nv = (struct nv_pair){ "tls_crypto_profile", "quantum", NULL };
+	assert(tls_crypto_profile_parser(&nv, 1, &config) == 1);
+}
+
+static void test_tls_require_pqc_compat_alias(void)
+{
+	struct daemon_conf config;
+	struct nv_pair nv;
+
+	memset(&config, 0, sizeof(config));
+	reset_allocs(-1);
+
+	/* yes sets both tls_require_pqc and tls_crypto_profile */
+	config.tls_crypto_profile = TLS_PROFILE_STANDARD;
+	nv = (struct nv_pair){ "tls_require_pqc", "yes", NULL };
+	assert(tls_require_pqc_parser(&nv, 1, &config) == 0);
+	assert(config.tls_require_pqc == 1);
+	assert(config.tls_crypto_profile == TLS_PROFILE_PQC);
+
+	/* no is a no-op for tls_crypto_profile */
+	config.tls_crypto_profile = TLS_PROFILE_PQC;
+	nv = (struct nv_pair){ "tls_require_pqc", "no", NULL };
+	assert(tls_require_pqc_parser(&nv, 1, &config) == 0);
+	assert(config.tls_require_pqc == 0);
+	assert(config.tls_crypto_profile == TLS_PROFILE_PQC);
+
+	/* Explicit profile after yes wins (last writer) */
+	config.tls_crypto_profile = TLS_PROFILE_STANDARD;
+	config.tls_require_pqc = 0;
+	nv = (struct nv_pair){ "tls_require_pqc", "yes", NULL };
+	assert(tls_require_pqc_parser(&nv, 1, &config) == 0);
+	assert(config.tls_crypto_profile == TLS_PROFILE_PQC);
+	nv = (struct nv_pair){ "tls_crypto_profile", "standard", NULL };
+	assert(tls_crypto_profile_parser(&nv, 1, &config) == 0);
+	assert(config.tls_crypto_profile == TLS_PROFILE_STANDARD);
+}
+#endif /* HAVE_TLS */
+
 int main(void)
 {
 	reset_allocs(-1);
 	test_name_preserves_old_value();
 	test_log_file_preserves_old_value();
 	test_set_config_dir_preserves_old_value();
+#ifdef HAVE_TLS
+	test_tls_auth_parser();
+	test_tls_crypto_profile_parser();
+	test_tls_require_pqc_compat_alias();
+#endif
 	return 0;
 }

--- a/src/test/auditd_config_alloc_test.c
+++ b/src/test/auditd_config_alloc_test.c
@@ -231,6 +231,70 @@ static void test_tls_require_pqc_compat_alias(void)
 	assert(tls_crypto_profile_parser(&nv, 1, &config) == 0);
 	assert(config.tls_crypto_profile == TLS_PROFILE_STANDARD);
 }
+static void test_sanity_check_tls(void)
+{
+	struct daemon_conf config;
+
+	printf("  sanity_check TLS constraints...\n");
+
+	/* cert/key pairing: cert without key must fail */
+	clear_config(&config);
+	config.transport = T_TLS;
+	config.tls_cert_file = "/cert";
+	config.tls_key_file = NULL;
+	assert(sanity_check(&config) == 1);
+
+	/* PSK + cert mutual exclusion */
+	clear_config(&config);
+	config.transport = T_TLS;
+	config.tls_psk_file = "/psk";
+	config.tls_cert_file = "/cert";
+	config.tls_key_file = "/key";
+	config.tls_psk_identity = "id";
+	config.tls_auth = TLS_AUTH_PSK;
+	assert(sanity_check(&config) == 1);
+
+	/* tls_auth=psk requires tls_psk_file */
+	clear_config(&config);
+	config.transport = T_TLS;
+	config.tls_auth = TLS_AUTH_PSK;
+	config.tls_psk_file = NULL;
+	config.tls_cert_file = "/cert";
+	config.tls_key_file = "/key";
+	assert(sanity_check(&config) == 1);
+
+	/* No credentials at all */
+	clear_config(&config);
+	config.transport = T_TLS;
+	assert(sanity_check(&config) == 1);
+
+	/* PSK requires identity or ACL */
+	clear_config(&config);
+	config.transport = T_TLS;
+	config.tls_psk_file = "/psk";
+	config.tls_auth = TLS_AUTH_PSK;
+	config.tls_psk_identity = NULL;
+	config.tls_allowed_clients = NULL;
+	assert(sanity_check(&config) == 1);
+
+	/* tls_require_pqc conflicts with non-PQC profile */
+	clear_config(&config);
+	config.transport = T_TLS;
+	config.tls_psk_file = "/psk";
+	config.tls_psk_identity = "id";
+	config.tls_auth = TLS_AUTH_PSK;
+	config.tls_require_pqc = 1;
+	config.tls_crypto_profile = TLS_PROFILE_STANDARD;
+	assert(sanity_check(&config) == 1);
+
+	/* Valid minimal PSK config should pass */
+	clear_config(&config);
+	config.transport = T_TLS;
+	config.tls_psk_file = "/psk";
+	config.tls_psk_identity = "id";
+	config.tls_auth = TLS_AUTH_PSK;
+	assert(sanity_check(&config) == 0);
+}
 #endif /* HAVE_TLS */
 
 int main(void)
@@ -243,6 +307,7 @@ int main(void)
 	test_tls_auth_parser();
 	test_tls_crypto_profile_parser();
 	test_tls_require_pqc_compat_alias();
+	test_sanity_check_tls();
 #endif
 	return 0;
 }


### PR DESCRIPTION
Layer Phase 0 TLS policy and operational features on top of the transport base in
  upstream/tls:

  - Identity validation, crypto profiles (standard/FIPS/PQC), and
  tls_auth/tls_crypto_profile config options
  - ACL parser with per-identity enable/disable and live SIGHUP reload (no restart
  needed for client revocation)
  - Structured TLS audit records for connection events
  - Non-blocking SSL_write for server ACKs with proper WANT_READ/WANT_WRITE
  differentiation
  - SIGCHLD signal safety (SA_RESTART + errno preservation)
  - Man pages and sample configs for the PSK tech preview
  - Unit tests for identity validation, profiles, ACL, config parsing, and sanity checks
  - Build system: explicit link dependencies, OPENSSL_LIBS override support