### PR TITLE
Fix supported architectures claim

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,8 +36,8 @@ an init script for OpenRC.
 ## SUPPORTED ARCHITECTURES
 * AARCH64
 * ARM (some versions)
-* MIPS
 * PPC & PPCLE
+* riscv32 & riscv64
 * s390 & s390x
 * x86_64 & i386
 


### PR DESCRIPTION
MIPS support was never merged upstream (#115, #198).

Not to be confused with RISC-V, which is supported now (#73).