### PR TITLE
Enable TLS in CI and remove unsupported certificate-mode references

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -32,7 +32,8 @@ jobs:
             libkrb5-dev \
             libcap-ng-dev \
             python3-dev swig \
-            libldap-dev
+            libldap-dev \
+            libssl-dev
 
       - name: Install dependencies (Fedora)
         if: matrix.container == 'fedora:latest'
@@ -44,7 +45,8 @@ jobs:
             krb5-devel \
             libcap-ng-devel \
             python3-devel python-unversioned-command swig \
-            openldap-devel
+            openldap-devel \
+            openssl-devel
 
       - name: Set compiler
         run: |
@@ -56,7 +58,7 @@ jobs:
           ./configure --with-python3=yes --enable-gssapi-krb5=yes \
             --with-arm --with-aarch64 --with-libcap-ng=yes \
             --without-golang --enable-zos-remote \
-            --enable-experimental --with-io_uring
+            --enable-experimental --with-io_uring --enable-tls
           make -j$(nproc)
 
       - name: Run tests

--- a/audisp/plugins/remote/audisp-remote.conf
+++ b/audisp/plugins/remote/audisp-remote.conf
@@ -40,7 +40,3 @@ startup_failure_action = warn_once_continue
 ##tls_cipher_suites = TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256
 ##tls_key_exchange = X25519MLKEM768:X25519
 ##tls_require_pqc = no
-## Certificate mode (not supported in this tech preview):
-##tls_cert_file = /etc/audit/tls/client-cert.pem
-##tls_key_file = /etc/audit/tls/client-key.pem
-##tls_ca_file = /etc/audit/tls/ca-cert.pem

--- a/audisp/plugins/remote/audisp-remote.conf.5
+++ b/audisp/plugins/remote/audisp-remote.conf.5
@@ -25,7 +25,7 @@ If set to
 .IR TCP ,
 the remote logging app will just make a normal clear text connection to the remote system. If set to
 .IR TLS ,
-the connection will be encrypted using TLS 1.3 with post-quantum hybrid key exchange. This requires either a pre-shared key (tls_psk_file) or certificates (tls_cert_file + tls_key_file) to be configured. Note that TLS transport requires format=managed; the ascii format does not support TLS encryption. If set to
+the connection will be encrypted using TLS 1.3 with post-quantum hybrid key exchange. This requires a pre-shared key (tls_psk_file) to be configured. Note that TLS transport requires format=managed; the ascii format does not support TLS encryption. If set to
 .IR KRB5 ",
 then Kerberos 5 will be used for authentication and encryption. The default value is TCP.
 .TP
@@ -220,15 +220,6 @@ Note that the key file must be owned by root and mode 0400.
 The default is
 .I /etc/audisp/audisp-remote.key
 .TP
-.I tls_cert_file
-Path to the client TLS certificate in PEM format. The file may contain the full certificate chain (leaf certificate followed by intermediate CA certificates). Used for certificate-based mutual TLS authentication. Either this (with tls_key_file) or tls_psk_file must be configured when transport is TLS. PSK and certificate authentication are mutually exclusive.
-.TP
-.I tls_key_file
-Path to the client TLS private key in PEM format. The file must be owned by root and mode 0400.
-.TP
-.I tls_ca_file
-Path to the CA certificate used to verify the remote server's TLS certificate. When set, server certificate verification is enabled using this CA. When not set in certificate mode (not PSK-only), the system CA store is used for server verification. In PSK-only mode without tls_ca_file, server certificate verification is skipped since PSK provides mutual authentication.
-.TP
 .I tls_auth
 The TLS authentication mode. Currently only
 .I psk
@@ -269,7 +260,7 @@ sets tls_crypto_profile to pqc. If set to
 has no effect on tls_crypto_profile. New configurations should use tls_crypto_profile directly.
 
 .SH "NOTES"
-Changes to TLS configuration options (tls_cert_file, tls_key_file, tls_ca_file, tls_psk_file, tls_psk_identity, tls_cipher_suites, tls_key_exchange, tls_require_pqc, tls_auth, tls_crypto_profile) in the configuration file are not re-read on SIGHUP. However, SIGHUP destroys the current TLS context and forces a full reconnection with a new context built from the current (unchanged) configuration. Because the PSK key file is re-read from disk during context creation, rotating the key file contents followed by SIGHUP will activate the new key.
+Changes to TLS configuration options (tls_psk_file, tls_psk_identity, tls_cipher_suites, tls_key_exchange, tls_require_pqc, tls_auth, tls_crypto_profile) in the configuration file are not re-read on SIGHUP. However, SIGHUP destroys the current TLS context and forces a full reconnection with a new context built from the current (unchanged) configuration. Because the PSK key file is re-read from disk during context creation, rotating the key file contents followed by SIGHUP will activate the new key.
 
 Specifying a local port may make it difficult to restart the audit
 subsystem due to the previous connection being in a TIME_WAIT state,

--- a/audisp/plugins/remote/remote-config.c
+++ b/audisp/plugins/remote/remote-config.c
@@ -984,37 +984,12 @@ static int sanity_check(remote_conf_t *config, const char *file)
 	}
 #ifdef HAVE_TLS
 	if (config->transport == T_TLS) {
-		int have_psk, have_cert;
-		if ((config->tls_cert_file != NULL) !=
-		    (config->tls_key_file != NULL)) {
+		if (config->tls_psk_file == NULL) {
 			syslog(LOG_ERR,
-				"tls_cert_file and tls_key_file must "
-				"both be set or both be unset");
+				"transport=tls requires tls_psk_file");
 			return 1;
 		}
-		have_psk = config->tls_psk_file != NULL;
-		have_cert = config->tls_cert_file != NULL &&
-				config->tls_key_file != NULL;
-		if (have_psk && have_cert) {
-			syslog(LOG_ERR,
-				"tls_psk_file and tls_cert_file are "
-				"mutually exclusive");
-			return 1;
-		}
-		if (config->tls_auth == TLS_AUTH_PSK && !have_psk) {
-			syslog(LOG_ERR,
-				"tls_auth=psk requires tls_psk_file; "
-				"certificate-based TLS is not supported "
-				"in this tech preview");
-			return 1;
-		}
-		if (!have_psk && !have_cert) {
-			syslog(LOG_ERR,
-				"transport=tls requires tls_psk_file or "
-				"tls_cert_file+tls_key_file");
-			return 1;
-		}
-		if (have_psk && !config->tls_psk_identity) {
+		if (!config->tls_psk_identity) {
 			syslog(LOG_ERR,
 				"tls_psk_identity is required when "
 				"tls_psk_file is set");

--- a/docs/auditd.conf.5
+++ b/docs/auditd.conf.5
@@ -322,7 +322,7 @@ If set to
 .IR TCP ",
 only clear text tcp connections will be used. If set to
 .IR TLS ",
-connections will be encrypted using TLS 1.3 with post-quantum hybrid key exchange. This requires either a pre-shared key (tls_psk_file) or server certificates (tls_cert_file + tls_key_file) to be configured. If set to
+connections will be encrypted using TLS 1.3 with post-quantum hybrid key exchange. This requires a pre-shared key (tls_psk_file) to be configured. If set to
 .IR KRB5 ",
 then Kerberos 5 will be used for authentication and encryption. The
 default value is TCP.  Changes to this option take effect only after
@@ -351,19 +351,10 @@ Note that the key file must be owned by root and mode 0400.
 The default is
 .I /etc/audit/audit.key
 .TP
-.I tls_cert_file
-Path to the server TLS certificate in PEM format. The file may contain the full certificate chain (leaf certificate followed by intermediate CA certificates). Used for certificate-based TLS authentication. PSK and certificate authentication are mutually exclusive.
-.TP
-.I tls_key_file
-Path to the server TLS private key in PEM format. The file must be owned by root and mode 0400.
-.TP
-.I tls_ca_file
-Path to the CA certificate used to verify client certificates when mutual TLS is enabled via tls_client_auth.
-.TP
 .I tls_auth
 The TLS authentication mode. Currently only
 .I psk
-is supported (pre-shared key authentication). Certificate-based TLS authentication is not supported in this tech preview. The default is
+is supported (pre-shared key authentication). The default is
 .IR psk .
 .TP
 .I tls_crypto_profile
@@ -407,12 +398,6 @@ Compatibility alias for tls_crypto_profile=pqc. If set to
 sets tls_crypto_profile to pqc. If set to
 .IR no ,
 it has no effect on tls_crypto_profile (one-directional alias). New configurations should use tls_crypto_profile directly.
-.TP
-.I tls_client_auth
-Controls client certificate verification for mutual TLS (certificate mode only). Valid values are
-.IR none ", " optional ", and " required ".
-This option is ignored when tls_auth=psk. The default is
-.IR none .
 .TP
 .I distribute_network
 If set to "yes", network originating events will be distributed to the audit
@@ -481,7 +466,7 @@ and
 .I verify_email
 .
 .SH NOTES
-Changes to TLS configuration options (tls_cert_file, tls_key_file, tls_ca_file, tls_psk_file, tls_psk_identity, tls_cipher_suites, tls_key_exchange, tls_require_pqc, tls_client_auth, tls_auth, tls_crypto_profile) require a full daemon restart to take effect. The tls_allowed_clients ACL file is reloaded on SIGHUP without restarting the daemon.
+Changes to TLS configuration options (tls_psk_file, tls_psk_identity, tls_cipher_suites, tls_key_exchange, tls_require_pqc, tls_auth, tls_crypto_profile) require a full daemon restart to take effect. The tls_allowed_clients ACL file is reloaded on SIGHUP without restarting the daemon.
 .PP
 In a CAPP environment, the audit trail is considered so important that access to system resources must be denied if an audit trail cannot be created. In this environment, it would be suggested that /var/log/audit be on its own partition. This is to ensure that space detection is accurate and that no other process comes along and consumes part of it.
 .PP

--- a/init.d/auditd.conf
+++ b/init.d/auditd.conf
@@ -43,11 +43,6 @@ krb5_principal = auditd
 ##tls_cipher_suites = TLS_AES_256_GCM_SHA384:TLS_AES_128_GCM_SHA256
 ##tls_key_exchange = X25519MLKEM768:X25519
 ##tls_require_pqc = no
-## Certificate mode (not supported in this tech preview):
-##tls_cert_file = /etc/audit/tls/server-cert.pem
-##tls_key_file = /etc/audit/tls/server-key.pem
-##tls_ca_file = /etc/audit/tls/ca-cert.pem
-##tls_client_auth = none
 distribute_network = no
 q_depth = 2000
 overflow_action = SYSLOG

--- a/src/auditd-config.c
+++ b/src/auditd-config.c
@@ -2282,37 +2282,12 @@ static int sanity_check(struct daemon_conf *config)
 	}
 #ifdef HAVE_TLS
 	if (config->transport == T_TLS) {
-		int have_psk, have_cert;
-		if ((config->tls_cert_file != NULL) !=
-		    (config->tls_key_file != NULL)) {
+		if (config->tls_psk_file == NULL) {
 			audit_msg(LOG_ERR,
-				"tls_cert_file and tls_key_file must "
-				"both be set or both be unset");
+				"transport=tls requires tls_psk_file");
 			return 1;
 		}
-		have_psk = config->tls_psk_file != NULL;
-		have_cert = config->tls_cert_file != NULL &&
-				config->tls_key_file != NULL;
-		if (have_psk && have_cert) {
-			audit_msg(LOG_ERR,
-				"tls_psk_file and tls_cert_file are "
-				"mutually exclusive");
-			return 1;
-		}
-		if (config->tls_auth == TLS_AUTH_PSK && !have_psk) {
-			audit_msg(LOG_ERR,
-				"tls_auth=psk requires tls_psk_file; "
-				"certificate-based TLS is not supported "
-				"in this tech preview");
-			return 1;
-		}
-		if (!have_psk && !have_cert) {
-			audit_msg(LOG_ERR,
-				"transport=tls requires tls_psk_file or "
-				"tls_cert_file+tls_key_file");
-			return 1;
-		}
-		if (have_psk && !config->tls_psk_identity &&
+		if (!config->tls_psk_identity &&
 		    !config->tls_allowed_clients) {
 			audit_msg(LOG_ERR,
 				"tls_psk_identity or tls_allowed_clients "
@@ -2334,20 +2309,6 @@ static int sanity_check(struct daemon_conf *config)
 				"tls_require_pqc=yes conflicts with "
 				"tls_crypto_profile; use "
 				"tls_crypto_profile=pqc instead");
-			return 1;
-		}
-		if (config->tls_client_auth > TCA_NONE &&
-				config->tls_auth == TLS_AUTH_PSK) {
-			audit_msg(LOG_WARNING,
-				"tls_client_auth is ignored when "
-				"tls_auth=psk; PSK identity "
-				"authorization is used instead");
-		}
-		if (have_cert && config->tls_client_auth > TCA_NONE &&
-				!config->tls_ca_file) {
-			audit_msg(LOG_ERR,
-				"tls_client_auth=optional/required "
-				"requires tls_ca_file");
 			return 1;
 		}
 	}

--- a/src/test/auditd_config_alloc_test.c
+++ b/src/test/auditd_config_alloc_test.c
@@ -250,35 +250,11 @@ static void test_sanity_check_tls(void)
 
 	printf("  sanity_check TLS constraints...\n");
 
-	/* cert/key pairing: cert without key must fail */
-	clear_sane_config(&config);
-	config.transport = T_TLS;
-	config.tls_cert_file = "/cert";
-	config.tls_key_file = NULL;
-	assert(sanity_check(&config) == 1);
-
-	/* PSK + cert mutual exclusion */
-	clear_sane_config(&config);
-	config.transport = T_TLS;
-	config.tls_psk_file = "/psk";
-	config.tls_cert_file = "/cert";
-	config.tls_key_file = "/key";
-	config.tls_psk_identity = "id";
-	config.tls_auth = TLS_AUTH_PSK;
-	assert(sanity_check(&config) == 1);
-
-	/* tls_auth=psk requires tls_psk_file */
+	/* transport=tls requires tls_psk_file */
 	clear_sane_config(&config);
 	config.transport = T_TLS;
 	config.tls_auth = TLS_AUTH_PSK;
 	config.tls_psk_file = NULL;
-	config.tls_cert_file = "/cert";
-	config.tls_key_file = "/key";
-	assert(sanity_check(&config) == 1);
-
-	/* No credentials at all */
-	clear_sane_config(&config);
-	config.transport = T_TLS;
 	assert(sanity_check(&config) == 1);
 
 	/* PSK requires identity or ACL */


### PR DESCRIPTION
- Add --enable-tls and OpenSSL dev packages to the CI build matrix so TLS code is compiled and tested on both GCC/Clang across Ubuntu and Fedora.
- Remove certificate-mode options (tls_cert_file, tls_key_file, tls_ca_file, tls_client_auth) from man pages and default config files, and simplify sanity_check() validation to PSK-only logic — only PSK authentication is functional.