### PR TITLE
Use _exit in forked children after exec failure

### DIFF
--- a/audisp/plugins/filter/audisp-filter.c
+++ b/audisp/plugins/filter/audisp-filter.c
@@ -514,13 +514,13 @@ int main(int argc, const char* argv[])
 		    config.binary_args[0] == NULL) {
 			syslog(LOG_ERR,
 			       "audisp-filter: missing child command");
-			exit(1);
+			_exit(EXIT_FAILURE); // Avoid running the atexit handlers.
 		}
 
 		execve(config.binary, config.binary_args, NULL);
 		syslog(LOG_ERR, "audisp-filter: execve failed (%s)",
 		       strerror(errno));
-		exit(1);
+		_exit(EXIT_FAILURE); // Avoid running the atexit handlers.
 	} else {
 		/* Parent reads input and forwards data after filters have been applied
 		 */

--- a/audisp/plugins/ids/reactions.c
+++ b/audisp/plugins/ids/reactions.c
@@ -102,7 +102,7 @@ static int safe_exec(const char *exe, ...)
 
 	execve(exe, argv, NULL);
 	syslog(LOG_ALERT, "Audit IDS failed to exec %s", exe);
-	exit(1);
+	_exit(EXIT_FAILURE); // Avoid running the atexit handlers.
 }
 
 static void minipause(void)

--- a/audisp/plugins/remote/audisp-remote.c
+++ b/audisp/plugins/remote/audisp-remote.c
@@ -327,7 +327,7 @@ static void safe_exec(const char *exe, const char *message)
 	argv[2] = NULL;
 	execve(exe, argv, NULL);
 	syslog(LOG_ALERT, "audisp-remote failed to exec %s", exe);
-	exit(1);
+	_exit(EXIT_FAILURE); // Avoid running the atexit handlers.
 }
 
 static int do_action (const char *desc, const char *message,

--- a/common/common.c
+++ b/common/common.c
@@ -262,6 +262,6 @@ void change_runlevel(const char *level)
 	argv[2] = NULL;
 	execve(init_pgm, argv, NULL);
 	audit_msg(LOG_ALERT, "%s failed to exec %s", get_progname(), init_pgm);
-	exit(1);
+	_exit(EXIT_FAILURE); // Avoid running the atexit handlers.
 }
 


### PR DESCRIPTION
Forked children that called exit() after a failed execve() would run the parent's atexit handlers.  In auditd the clean_exit() handler calls audit_set_pid(fd, 0), which deregisters the daemon from the kernel, and unlinks the PID file.  When the real parent keeps running it silently stops receiving audit events.

The same class of problem was fixed for the sendmail helper in 7965bc1a ("Use _exit after sendmail exec failure").  Apply the identical fix to every remaining site:

- common/common.c       change_runlevel() child
- audisp/plugins/ids/reactions.c  safe_exec() child
- audisp/plugins/remote/audisp-remote.c  safe_exec() child
- audisp/plugins/filter/audisp-filter.c  execve() child