### PR TITLE
Fix comm truncation, manpage check, completions and tmpfiles for /run/audit

### DIFF
--- a/docs/audit_log_user_comm_message.3
+++ b/docs/audit_log_user_comm_message.3
@@ -33,7 +33,8 @@ The kernel task command name is limited to 15 bytes because
 .B TASK_COMM_LEN
 is 16 bytes including the terminating null byte. A non-NULL
 .I comm
-value longer than 15 bytes is malformed and is rejected.
+value longer than 15 bytes is truncated to 15 bytes and a warning
+is logged.
 
 .SH "RETURN VALUE"
 
@@ -42,11 +43,6 @@ It returns the sequence number which is > 0 on success or <= 0 on error.
 .SH "ERRORS"
 
 This function returns \-1 on failure. Examine errno for more info.
-.TP
-.B EINVAL
-The
-.I comm
-value is longer than the kernel task command name limit of 15 bytes.
 
 .SH "SEE ALSO"
 

--- a/docs/check-manpages.sh
+++ b/docs/check-manpages.sh
@@ -46,6 +46,13 @@ sort -u "$page_list" -o "$page_list" || exit 1
 while IFS= read -r page; do
 	found=1
 
+	# .so-only stubs redirect to another page via a manpath-relative
+	# path (e.g. "man3/foo.3") that cannot resolve under man -l.
+	# Skip them; they work correctly once installed.
+	if grep -qx '\.so man[0-9]/.*' "$page" 2>/dev/null; then
+		continue
+	fi
+
 	output=$(
 		LC_ALL=C.UTF-8 MANROFFSEQ='' MANWIDTH=80 \
 			"$MAN" --warnings -E UTF-8 -l -Tutf8 -Z "$page" \

--- a/init.d/Makefile.am
+++ b/init.d/Makefile.am
@@ -58,8 +58,12 @@ install-exec-hook:
 	$(INSTALL_SCRIPT) -D -m 644 ${builddir}/auditd.service ${DESTDIR}${initdir}
 	$(INSTALL_SCRIPT) -D -m 644 ${builddir}/audit-rules.service ${DESTDIR}${initdir}
 	chmod 0755 $(DESTDIR)$(sbindir)/augenrules
-	$(INSTALL_SCRIPT) -D -m 644 ${srcdir}/audit.bash_completion \
-		${DESTDIR}${bashcompdir}
+	$(INSTALL_DATA) -D -m 644 ${srcdir}/audit.bash_completion \
+		${DESTDIR}${bashcompdir}/auditctl
+	cd ${DESTDIR}${bashcompdir} && \
+		ln -sf auditctl ausearch && \
+		ln -sf auditctl aureport && \
+		ln -sf auditctl augenrules
 if INSTALL_LEGACY_ACTIONS
 	mkdir -p ${DESTDIR}${legacydir}
 	$(INSTALL_SCRIPT) -D -m 750 ${srcdir}/auditd.rotate ${DESTDIR}${legacydir}/rotate
@@ -85,4 +89,7 @@ if INSTALL_LEGACY_ACTIONS
 	rm ${DESTDIR}${legacydir}/condrestart
 endif
 	rm ${DESTDIR}$(prefix)/lib/tmpfiles.d/audit.conf
-	rm ${DESTDIR}${bashcompdir}/audit.bash_completion
+	rm ${DESTDIR}${bashcompdir}/auditctl
+	rm ${DESTDIR}${bashcompdir}/ausearch
+	rm ${DESTDIR}${bashcompdir}/aureport
+	rm ${DESTDIR}${bashcompdir}/augenrules

--- a/init.d/audit-tmpfiles.conf
+++ b/init.d/audit-tmpfiles.conf
@@ -1,1 +1,2 @@
+d /run/audit 0700 root root - -
 d /var/log/audit 0700 root root - -

--- a/lib/audit_logging.c
+++ b/lib/audit_logging.c
@@ -231,8 +231,10 @@ static char *_get_commname(const char *comm, char *commname, unsigned int size)
 
 	len = strnlen(comm, AUDIT_COMM_LEN);
 	if (len == AUDIT_COMM_LEN) {
-		errno = EINVAL;
-		return NULL;
+		audit_msg(LOG_WARNING,
+			"comm value truncated to %d bytes",
+			AUDIT_COMM_LEN - 1);
+		len = AUDIT_COMM_LEN - 1;
 	}
 	if (audit_value_needs_encoding(comm, len))
 		audit_encode_value(commname, comm, len);

--- a/lib/test/lookup_test.c
+++ b/lib/test/lookup_test.c
@@ -482,7 +482,7 @@ test_audit_logging_encoding(void)
 }
 
 /*
- * Test audit logging task command length validation.
+ * Test that an overlong comm value is truncated rather than rejected.
  * Input variables: none. Return codes: none, aborts on failure.
  */
 static void
@@ -498,8 +498,10 @@ test_audit_logging_comm_length(void)
 	errno = 0;
 	rc = audit_log_user_comm_message(0, AUDIT_USER, "test", comm,
 					 NULL, NULL, "", 1);
-	assert(rc == -1);
-	assert(errno == EINVAL);
+	/* Overlong comm is truncated, not rejected. The call itself
+	 * may still fail (fd 0 is not an audit socket) but NOT with
+	 * EINVAL from comm validation. */
+	assert(errno != EINVAL);
 }
 
 int


### PR DESCRIPTION
Here are a couple of small fixes for issues identified when packaging audit 4.2:
- libaudit: Truncate overlong comm values instead of rejecting them, preventing audit rule failures for processes with long command names
- docs: Skip .so redirect stubs in the manpage completeness check so they don't cause false failures
- init.d: Create /run/audit via tmpfiles.d instead of relying on the daemon to create it at startup
-  init.d: Install bash completions under per-command names (auditctl, ausearch, aureport, augenrules) so they auto-load; previously installed as audit.bash_completion which bash-completion never discovered
