### PR TITLE
Add Landlock audit types

### DIFF
--- a/lib/audit-records.h
+++ b/lib/audit-records.h
@@ -104,6 +104,10 @@ extern "C" {
 #define AUDIT_LAST_EVENT        1399
 
 #define AUDIT_FIRST_SELINUX     1400
+#ifndef AUDIT_LANDLOCK_ACCESS
+#define AUDIT_LANDLOCK_ACCESS   1423
+#define AUDIT_LANDLOCK_DOMAIN   1424
+#endif
 #define AUDIT_LAST_SELINUX      1499
 
 #define AUDIT_FIRST_APPARMOR            1500

--- a/lib/msg_typetab.h
+++ b/lib/msg_typetab.h
@@ -22,7 +22,7 @@
 
 /*
  * This table is arranged from lowest number to highest number. The
- * items that are commented out are for completeness. The audit 
+ * items that are commented out are for completeness. The audit
  * daemon filters these and they never show up in the logs, therefore
  * they are not needed for reporting. Or they have been deprecated for
  * a long time.
@@ -93,6 +93,8 @@ _S(AUDIT_DAEMON_RESUME,              "DAEMON_RESUME"                 )
 _S(AUDIT_DAEMON_ACCEPT,              "DAEMON_ACCEPT"                 )
 _S(AUDIT_DAEMON_CLOSE,               "DAEMON_CLOSE"                  )
 _S(AUDIT_DAEMON_ERR,                 "DAEMON_ERR"                    )
+_S(AUDIT_LANDLOCK_ACCESS,            "LANDLOCK_ACCESS"               )
+_S(AUDIT_LANDLOCK_DOMAIN,            "LANDLOCK_DOMAIN"               )
 _S(AUDIT_SYSCALL,                    "SYSCALL"                       )
 //_S(AUDIT_FS_WATCH,                 "FS_WATCH"                      )
 _S(AUDIT_PATH,                       "PATH"                          )


### PR DESCRIPTION
Audit messages produced by Landlock were written as `type=UNKNOWN[1423]` in `/var/log/audit/audit.log`, while the [Landlock docs](https://docs.kernel.org/admin-guide/LSM/landlock.html) uses the `LANDLOCK_ACCESS` and `LANDLOCK_DOMAIN` names.

There is also an issue with how `mode=` is handled -- Landlock outputs `mode=enforcing`, while interpret.c treats it like a file permission and tries to parse it into a string.
I didn't attempt to fix the issue as it's not relevant at the moment (`enforcing` is the only Landlock mode).