### PR TITLE
aureport: fix AVC result column always showing "unset"

### DIFF
--- a/src/ausearch-parse.c
+++ b/src/ausearch-parse.c
@@ -2037,19 +2037,21 @@ static int parse_avc(const lnode *n, search_items *s)
 			term = n->message;
 			goto other_avc;
 		}
-		// Do not override syscall success if already set.
-		// Syscall pass/fail is the authoritative value.
-		if (event_success != S_UNSET && s->success == S_UNSET) {
-			*term = 0;
-			if (strstr(str, "denied")) {
+		// Always record the AVC verdict (denied/granted) from the record.
+		// Only propagate it to s->success when a success filter is active
+		// and s->success hasn't been set yet; syscall pass/fail is the
+		// authoritative value and must not be overwritten.
+		*term = 0;
+		if (strstr(str, "denied")) {
+			an.avc_result = AVC_DENIED;
+			if (event_success != S_UNSET && s->success == S_UNSET)
 				s->success = S_FAILED;
-				an.avc_result = AVC_DENIED;
-			} else {
+		} else {
+			an.avc_result = AVC_GRANTED;
+			if (event_success != S_UNSET && s->success == S_UNSET)
 				s->success = S_SUCCESS;
-				an.avc_result = AVC_GRANTED;
-			}
-			*term = '{';
 		}
+		*term = '{';
 
 		// Now get permission
 		str = term + 1;


### PR DESCRIPTION
When running `aureport -a` without a `--success` or `--failed` filter,
the result column in the AVC report always shows "unset" instead of
"denied" or "granted", even though the raw audit record clearly contains
the verdict.

## Root cause

In `parse_avc()`, two unrelated things were done inside one guard:

```c
if (event_success != S_UNSET && s->success == S_UNSET) {
    an.avc_result = AVC_DENIED / AVC_GRANTED;
    s->success    = S_FAILED  / S_SUCCESS;
}
```

The guard exists to protect `s->success`: only copy the AVC verdict
into the event's success field when the user is actively filtering by
success/failure, and only if it hasn't been set by a SYSCALL record yet
(syscall result is authoritative).

The problem is that `an.avc_result` — the field aureport prints in the
result column — was also trapped inside that guard. Without a filter,
`event_success == S_UNSET`, so the whole block was skipped and
`an.avc_result` stayed at its initial value of `AVC_UNSET`.
`aulookup_result(AVC_UNSET)` returns the string `"unset"`.

## Fix

Separate the two concerns. Always read the verdict from the record into
`an.avc_result`. Keep the guard only around the `s->success` assignment.