### PR TITLE
init.d: Install tmpfiles config file under more relaxed perms

### DIFF
--- a/init.d/Makefile.am
+++ b/init.d/Makefile.am
@@ -50,7 +50,7 @@ BUILT_SOURCES = auditd.service audit-rules.service augenrules
 install-data-hook:
 	$(INSTALL_DATA) -D -m 640 ${srcdir}/${libconfig} ${DESTDIR}${sysconfdir}
 	mkdir -p ${DESTDIR}$(prefix)/lib/tmpfiles.d/
-	$(INSTALL_DATA) -m 640 ${srcdir}/audit-tmpfiles.conf ${DESTDIR}$(prefix)/lib/tmpfiles.d/audit.conf
+	$(INSTALL_DATA) -m 644 ${srcdir}/audit-tmpfiles.conf ${DESTDIR}$(prefix)/lib/tmpfiles.d/audit.conf
 
 install-exec-hook:
 	mkdir -p ${DESTDIR}${initdir}


### PR DESCRIPTION
Contents of this file are not a secret that should not be read by other users/tools.

In Flatcar are doing some postprocessing of tmpfiles config files when building the images and this one file failed to be read because of permission being denied.